### PR TITLE
Apply Autocomplete Lookup values to query

### DIFF
--- a/us-autocomplete-api/client.go
+++ b/us-autocomplete-api/client.go
@@ -3,6 +3,8 @@ package autocomplete
 import (
 	"encoding/json"
 	"net/http"
+	"strconv"
+	"strings"
 
 	"github.com/smartystreets/smartystreets-go-sdk"
 )
@@ -41,10 +43,17 @@ func deserializeResponse(response []byte, lookup *Lookup) error {
 func buildRequest(lookup *Lookup) *http.Request {
 	request, _ := http.NewRequest("GET", suggestURL, nil) // We control the method and the URL. This is safe.
 	query := request.URL.Query()
+
+	// Apply lookup values to query
 	query.Set("prefix", lookup.Prefix)
-	// TODO: additional input fields
+	query.Set("suggestions", strconv.Itoa(lookup.MaxSuggestions))
+	query.Set("city_filter", strings.Join(lookup.CityFilter, ","))
+	query.Set("state_filter", strings.Join(lookup.StateFilter, ","))
+	query.Set("prefer", strings.Join(lookup.CityStatePreferences, ";"))
+
 	request.URL.RawQuery = query.Encode()
 	request.Header.Set("Content-Type", "application/json")
+
 	return request
 }
 

--- a/us-autocomplete-api/client.go
+++ b/us-autocomplete-api/client.go
@@ -52,8 +52,6 @@ func buildRequest(lookup *Lookup) *http.Request {
 	query.Set("prefer", strings.Join(lookup.CityStatePreferences, ";"))
 
 	request.URL.RawQuery = query.Encode()
-	request.Header.Set("Content-Type", "application/json")
-
 	return request
 }
 

--- a/us-autocomplete-api/lookup.go
+++ b/us-autocomplete-api/lookup.go
@@ -4,11 +4,11 @@ type (
 	// Lookup represents all input fields documented here:
 	// https://smartystreets.com/docs/us-autocomplete-api#http-request-input-fields
 	Lookup struct {
-		Prefix               string
-		MaxSuggestions       int
-		CityFilter           []string
-		StateFilter          []string
-		CityStatePreferences []string
+		Prefix               string   `json:"prefix,omitempty"`
+		MaxSuggestions       int      `json:"suggestions,omitempty"`
+		CityFilter           []string `json:"city_filter,omitempty"`
+		StateFilter          []string `json:"state_filter,omitempty"`
+		CityStatePreferences []string `json:"prefer,omitempty"`
 		Geolocation          GeolocateMode
 
 		Results []*Suggestion


### PR DESCRIPTION
This PR adds codes that applies the values of Autocomplete Lookup to the query in `buildRequest()`.

Here are some questions though:
- I wasn't entirely sure how you intended to handle `Geolocation` in Lookup.

Thanks! Feedback is much appreciated.