### PR TITLE
Un-exported the clientBuilder, its constructor and methods.

### DIFF
--- a/examples/us-street-api/main.go
+++ b/examples/us-street-api/main.go
@@ -15,7 +15,7 @@ func main() {
 	// You don't have to store your keys in environment variables, but we recommend it.
 	client := wireup.BuildUSStreetAPIClient(
 		wireup.SecretKeyCredential(os.Getenv("SMARTY_AUTH_ID"), os.Getenv("SMARTY_AUTH_TOKEN")),
-		//wireup.ViaProxy("https://my-proxy.my-company.com"), // uncomment this line to point to the specified proxy.
+		//wireup.viaProxy("https://my-proxy.my-company.com"), // uncomment this line to point to the specified proxy.
 		//wireup.DebugHTTPOutput(), // uncomment this line to see detailed HTTP request/response information.
 	)
 

--- a/wireup/builder.go
+++ b/wireup/builder.go
@@ -15,25 +15,7 @@ import (
 	"github.com/smartystreets/smartystreets-go-sdk/us-zipcode-api"
 )
 
-// ClientBuilder is responsible for accepting credentials and other configuration options to combine
-// all components necessary to assemble a fully functional Client for use in an application.
-//
-// Deprecated: This type (and all associated functions and methods) will be unexported in the future.
-//
-// Instead of this kind of wireup:
-//
-// 	client := NewClientBuilder().
-// 		WithSecretKeyCredential("auth-id", "auth-token").
-// 		WithTimeout(time.Second*20).
-// 		BuildUSStreetAPIClient()
-//
-// Please migrate to this approach instead:
-//
-// 	client := BuildUSStreetAPIClient(
-// 		SecretKeyCredential("auth-id", "auth-token"),
-// 		Timeout(time.Second*20),
-// 	)
-type ClientBuilder struct {
+type clientBuilder struct {
 	credential sdk.Credential
 	baseURL    *url.URL
 	proxy      *url.URL
@@ -45,9 +27,8 @@ type ClientBuilder struct {
 	headers    http.Header
 }
 
-// Deprecated: (see ClientBuilder godoc for details)
-func NewClientBuilder() *ClientBuilder {
-	return &ClientBuilder{
+func newClientBuilder() *clientBuilder {
+	return &clientBuilder{
 		credential: &internal.NopCredential{},
 		retries:    4,
 		timeout:    time.Second * 10,
@@ -61,14 +42,12 @@ func initializeHeadersWithUserAgent() http.Header {
 	return headers
 }
 
-// Deprecated: (see ClientBuilder godoc for details)
-func (b *ClientBuilder) WithSecretKeyCredential(authID, authToken string) *ClientBuilder {
+func (b *clientBuilder) withSecretKeyCredential(authID, authToken string) *clientBuilder {
 	b.credential = sdk.NewSecretKeyCredential(authID, authToken)
 	return b
 }
 
-// Deprecated: (see ClientBuilder godoc for details)
-func (b *ClientBuilder) WithCustomBaseURL(address string) *ClientBuilder {
+func (b *clientBuilder) withCustomBaseURL(address string) *clientBuilder {
 	parsed, err := url.Parse(address)
 	if err != nil {
 		panic(fmt.Sprint("Could not parse provided address:", err.Error()))
@@ -77,8 +56,7 @@ func (b *ClientBuilder) WithCustomBaseURL(address string) *ClientBuilder {
 	return b
 }
 
-// Deprecated: (see ClientBuilder godoc for details)
-func (b *ClientBuilder) WithMaxRetry(retries int) *ClientBuilder {
+func (b *clientBuilder) withMaxRetry(retries int) *clientBuilder {
 	if retries < 0 {
 		panic(fmt.Sprintf("Please provide a non-negative number of retry attempts (you supplied %d).", retries))
 	}
@@ -86,8 +64,7 @@ func (b *ClientBuilder) WithMaxRetry(retries int) *ClientBuilder {
 	return b
 }
 
-// Deprecated: (see ClientBuilder godoc for details)
-func (b *ClientBuilder) WithTimeout(duration time.Duration) *ClientBuilder {
+func (b *clientBuilder) withTimeout(duration time.Duration) *clientBuilder {
 	if duration < 0 {
 		panic(fmt.Sprintf("Please provide a non-negative duration (you supplied %s).", duration.String()))
 	}
@@ -95,31 +72,27 @@ func (b *ClientBuilder) WithTimeout(duration time.Duration) *ClientBuilder {
 	return b
 }
 
-// Deprecated: (see ClientBuilder godoc for details)
-func (b *ClientBuilder) WithDebugHTTPOutput() *ClientBuilder {
+func (b *clientBuilder) withDebugHTTPOutput() *clientBuilder {
 	b.debug = true
 	return b
 }
 
-// Deprecated: (see ClientBuilder godoc for details)
-func (b *ClientBuilder) WithHTTPRequestTracing() *ClientBuilder {
+func (b *clientBuilder) withHTTPRequestTracing() *clientBuilder {
 	b.trace = true
 	return b
 }
 
-// Deprecated: (see ClientBuilder godoc for details)
-func (b *ClientBuilder) WithCustomHeader(key, value string) *ClientBuilder {
+func (b *clientBuilder) withCustomHeader(key, value string) *clientBuilder {
 	b.headers.Add(key, value)
 	return b
 }
 
-func (b *ClientBuilder) WithoutKeepAlive() *ClientBuilder {
+func (b *clientBuilder) withoutKeepAlive() *clientBuilder {
 	b.close = true
 	return b
 }
 
-// Deprecated: (see ClientBuilder godoc for details)
-func (b *ClientBuilder) ViaProxy(address string) *ClientBuilder {
+func (b *clientBuilder) viaProxy(address string) *clientBuilder {
 	proxy, err := url.Parse(address)
 	if err != nil {
 		panic(fmt.Sprint("Could not parse provided address:", err.Error()))
@@ -128,48 +101,43 @@ func (b *ClientBuilder) ViaProxy(address string) *ClientBuilder {
 	return b
 }
 
-// Deprecated: (see ClientBuilder godoc for details)
-func (b *ClientBuilder) BuildUSStreetAPIClient() *street.Client {
+func (b *clientBuilder) buildUSStreetAPIClient() *street.Client {
 	b.ensureBaseURLNotNil(defaultBaseURL_USStreetAPI)
 	return street.NewClient(b.buildHTTPSender())
 }
 
-// Deprecated: (see ClientBuilder godoc for details)
-func (b *ClientBuilder) BuildUSZIPCodeAPIClient() *zipcode.Client {
+func (b *clientBuilder) buildUSZIPCodeAPIClient() *zipcode.Client {
 	b.ensureBaseURLNotNil(defaultBaseURL_USZIPCodeAPI)
 	return zipcode.NewClient(b.buildHTTPSender())
 }
 
-// Deprecated: (see ClientBuilder godoc for details)
-func (b *ClientBuilder) BuildUSAutocompleteAPIClient() *autocomplete.Client {
+func (b *clientBuilder) buildUSAutocompleteAPIClient() *autocomplete.Client {
 	b.ensureBaseURLNotNil(defaultBaseURL_USAutocompleteAPI)
 	return autocomplete.NewClient(b.buildHTTPSender())
 }
 
-// Deprecated: (see ClientBuilder godoc for details)
-func (b *ClientBuilder) BuildUSExtractAPIClient() *extract.Client {
+func (b *clientBuilder) buildUSExtractAPIClient() *extract.Client {
 	b.ensureBaseURLNotNil(defaultBaseURL_USExtractAPI)
 	return extract.NewClient(b.buildHTTPSender())
 }
 
-// Deprecated: (see ClientBuilder godoc for details)
-func (b *ClientBuilder) BuildInternationalStreetAPIClient() *international_street.Client {
+func (b *clientBuilder) buildInternationalStreetAPIClient() *international_street.Client {
 	b.ensureBaseURLNotNil(defaultBaseURL_InternationalStreetAPI)
 	return international_street.NewClient(b.buildHTTPSender())
 }
 
-func (b *ClientBuilder) ensureBaseURLNotNil(u *url.URL) {
+func (b *clientBuilder) ensureBaseURLNotNil(u *url.URL) {
 	if b.baseURL == nil {
 		b.baseURL = u
 	}
 }
 
-func (b *ClientBuilder) buildHTTPSender() *internal.HTTPSender {
+func (b *clientBuilder) buildHTTPSender() *internal.HTTPSender {
 	client := b.buildHTTPClient()
 	return internal.NewHTTPSender(client)
 }
 
-func (b *ClientBuilder) buildHTTPClient() (wrapped internal.HTTPClient) {
+func (b *clientBuilder) buildHTTPClient() (wrapped internal.HTTPClient) {
 	// inner-most
 	wrapped = &http.Client{Timeout: b.timeout, Transport: b.buildTransport()}
 	wrapped = internal.NewTracingClient(wrapped, b.trace)
@@ -183,7 +151,7 @@ func (b *ClientBuilder) buildHTTPClient() (wrapped internal.HTTPClient) {
 	return wrapped
 }
 
-func (b *ClientBuilder) buildTransport() *http.Transport {
+func (b *clientBuilder) buildTransport() *http.Transport {
 	transport := &http.Transport{}
 	if b.proxy != nil {
 		transport.Proxy = http.ProxyURL(b.proxy)

--- a/wireup/options.go
+++ b/wireup/options.go
@@ -12,43 +12,43 @@ import (
 
 // BuildUSStreetAPIClient builds a client for the US Street API using the provided options.
 func BuildUSStreetAPIClient(options ...Option) *street.Client {
-	return configure(options...).BuildUSStreetAPIClient()
+	return configure(options...).buildUSStreetAPIClient()
 }
 
 // BuildUSZIPCodeAPIClient builds a client for the US ZIP Code API using the provided options.
 func BuildUSZIPCodeAPIClient(options ...Option) *zipcode.Client {
-	return configure(options...).BuildUSZIPCodeAPIClient()
+	return configure(options...).buildUSZIPCodeAPIClient()
 }
 
 // BuildUSAutocompleteAPIClient builds a client for the US Autocomplete API using the provided options.
 func BuildUSAutocompleteAPIClient(options ...Option) *autocomplete.Client {
-	return configure(options...).BuildUSAutocompleteAPIClient()
+	return configure(options...).buildUSAutocompleteAPIClient()
 }
 
 // BuildUSExtractAPIClient builds a client for the US Extract API using the provided options.
 func BuildUSExtractAPIClient(options ...Option) *extract.Client {
-	return configure(options...).BuildUSExtractAPIClient()
+	return configure(options...).buildUSExtractAPIClient()
 }
 
 // BuildInternationalStreetAPIClient builds a client for the International Street API using the provided options.
 func BuildInternationalStreetAPIClient(options ...Option) *international_street.Client {
-	return configure(options...).BuildInternationalStreetAPIClient()
+	return configure(options...).buildInternationalStreetAPIClient()
 }
-func configure(options ...Option) *ClientBuilder {
-	builder := NewClientBuilder()
+func configure(options ...Option) *clientBuilder {
+	builder := newClientBuilder()
 	for _, option := range options {
 		option(builder)
 	}
 	return builder
 }
 
-type Option func(builder *ClientBuilder)
+type Option func(builder *clientBuilder)
 
 // SecretKeyCredential sets the authID and authToken for use with the client.
 // In all but very few cases calling this method with a valid authID and authToken is required.
 func SecretKeyCredential(authID, authToken string) Option {
-	return func(builder *ClientBuilder) {
-		builder.WithSecretKeyCredential(authID, authToken)
+	return func(builder *clientBuilder) {
+		builder.withSecretKeyCredential(authID, authToken)
 	}
 }
 
@@ -57,58 +57,58 @@ func SecretKeyCredential(authID, authToken string) Option {
 // The address provided should be a url that consists of only the scheme and host. Any other elements
 // (such as a path, query string, or fragment) will be ignored.
 func CustomBaseURL(address string) Option {
-	return func(builder *ClientBuilder) {
-		builder.WithCustomBaseURL(address)
+	return func(builder *clientBuilder) {
+		builder.withCustomBaseURL(address)
 	}
 }
 
 // MaxRetry specifies the number of times an API request will be resent in the
 // case of network errors or unexpected results.
 func MaxRetry(retries int) Option {
-	return func(builder *ClientBuilder) {
-		builder.WithMaxRetry(retries)
+	return func(builder *clientBuilder) {
+		builder.withMaxRetry(retries)
 	}
 }
 
 // Timeout specifies the timeout for all API requests.
 func Timeout(duration time.Duration) Option {
-	return func(builder *ClientBuilder) {
-		builder.WithTimeout(duration)
+	return func(builder *clientBuilder) {
+		builder.withTimeout(duration)
 	}
 }
 
 // DebugHTTPOutput engages detailed HTTP request/response logging using functions from net/http/httputil.
 func DebugHTTPOutput() Option {
-	return func(builder *ClientBuilder) {
-		builder.WithDebugHTTPOutput()
+	return func(builder *clientBuilder) {
+		builder.withDebugHTTPOutput()
 	}
 }
 
 // DebugHTTPTracing engages additional HTTP-level tracing for each API request.
 func DebugHTTPTracing() Option {
-	return func(builder *ClientBuilder) {
-		builder.WithHTTPRequestTracing()
+	return func(builder *clientBuilder) {
+		builder.withHTTPRequestTracing()
 	}
 }
 
 // CustomHeader ensures the provided header is added to every API request made with the resulting client.
 func CustomHeader(key, value string) Option {
-	return func(builder *ClientBuilder) {
-		builder.WithCustomHeader(key, value)
+	return func(builder *clientBuilder) {
+		builder.withCustomHeader(key, value)
 	}
 }
 
 // DisableKeepAlive disables keep-alive for API requests.
 // This is helpful if your environment limits the number of open files.
 func DisableKeepAlive() Option {
-	return func(builder *ClientBuilder) {
-		builder.WithoutKeepAlive()
+	return func(builder *clientBuilder) {
+		builder.withoutKeepAlive()
 	}
 }
 
-// ViaProxy saves the address of your proxy server through which to send all requests.
+// viaProxy saves the address of your proxy server through which to send all requests.
 func ViaProxy(address string) Option {
-	return func(builder *ClientBuilder) {
-		builder.ViaProxy(address)
+	return func(builder *clientBuilder) {
+		builder.viaProxy(address)
 	}
 }


### PR DESCRIPTION
This breaking change will illicit a new major version (7.x.x -> 8.0.0) when eventually merged into the master branch. Current forecast is for the merge to occur on or after **February 1, 2018**. It is now expected that clients will use the functions found in options.go for all wireup.