### PR TITLE
Fix lack of parameters in Zip query.

### DIFF
--- a/us-zipcode-api/batch.go
+++ b/us-zipcode-api/batch.go
@@ -57,24 +57,26 @@ func (b *Batch) Clear() {
 	b.lookups = nil
 }
 
-func (batch *Batch) buildRequest() *http.Request {
+func (b *Batch) buildRequest() *http.Request {
 	request, _ := http.NewRequest(http.MethodGet, placeholderURL, nil)
-	if batch.Length() == 1 {
-		batch.serializeGET(request)
+	if b.Length() == 1 {
+		b.serializeGET(request)
 	} else {
-		batch.serializePOST(request)
+		b.serializePOST(request)
 	}
 	return request
 }
-func (batch *Batch) serializeGET(request *http.Request) {
+
+func (b *Batch) serializeGET(request *http.Request) {
 	request.Method = http.MethodGet
 	query := request.URL.Query()
-	query.Set("input_id", batch.lookups[0].InputID)
+	b.lookups[0].encodeQueryString(query)
 	request.URL.RawQuery = query.Encode()
 }
-func (batch *Batch) serializePOST(request *http.Request) {
+
+func (b *Batch) serializePOST(request *http.Request) {
 	request.Method = http.MethodPost
-	payload, _ := json.Marshal(batch.lookups) // We control the types being serialized. This is safe.
+	payload, _ := json.Marshal(b.lookups) // We control the types being serialized. This is safe.
 	request.Body = ioutil.NopCloser(bytes.NewReader(payload))
 	request.ContentLength = int64(len(payload))
 	request.Header.Set("Content-Type", "application/json")

--- a/us-zipcode-api/client_test.go
+++ b/us-zipcode-api/client_test.go
@@ -32,7 +32,7 @@ func (f *ClientFixture) Setup() {
 
 func (f *ClientFixture) TestSingleLookupSerializedInQueryStringGET() {
 	f.sender.response = `[{"input_index": 0, "input_id": "42"}]`
-	input := &Lookup{InputID: "42"}
+	input := &Lookup{InputID: "42", ZIPCode: "10001", City: "NYC", State: "NY"}
 	f.batch.Append(input)
 
 	err := f.client.SendBatch(f.batch)
@@ -43,7 +43,7 @@ func (f *ClientFixture) TestSingleLookupSerializedInQueryStringGET() {
 	f.So(f.sender.request.URL.Path, should.Equal, "/lookup")
 	f.So(f.sender.requestBody, should.BeNil)
 	f.So(f.sender.request.URL.String(), should.StartWith, placeholderURL)
-	f.So(f.sender.request.URL.Query(), should.Resemble, url.Values{"input_id": {"42"}})
+	f.So(f.sender.request.URL.Query(), should.Resemble, url.Values{"input_id": {"42"}, "zipcode": {"10001"}, "city": {"NYC"}, "state": {"NY"}})
 }
 
 func (f *ClientFixture) TestLookupBatchSerializedAndSent__ResultsIncorporatedBackIntoBatch() {
@@ -52,8 +52,8 @@ func (f *ClientFixture) TestLookupBatchSerializedAndSent__ResultsIncorporatedBac
 		{"input_index": 1, "input_id": "43"},
 		{"input_index": 2, "input_id": "44"}
 	]`
-	input0 := &Lookup{InputID: "42"}
-	input1 := &Lookup{InputID: "43"}
+	input0 := &Lookup{InputID: "42", ZIPCode: "10001"}
+	input1 := &Lookup{InputID: "43", State: "NY", City: "NYC"}
 	input2 := &Lookup{InputID: "44"}
 	f.batch.Append(input0)
 	f.batch.Append(input1)
@@ -65,7 +65,7 @@ func (f *ClientFixture) TestLookupBatchSerializedAndSent__ResultsIncorporatedBac
 	f.So(f.sender.request, should.NotBeNil)
 	f.So(f.sender.request.Method, should.Equal, "POST")
 	f.So(f.sender.request.URL.Path, should.Equal, "/lookup")
-	f.So(string(f.sender.requestBody), should.Equal, `[{"input_id":"42"},{"input_id":"43"},{"input_id":"44"}]`)
+	f.So(string(f.sender.requestBody), should.Equal, `[{"zipcode":"10001","input_id":"42"},{"city":"NYC","state":"NY","input_id":"43"},{"input_id":"44"}]`)
 	f.So(f.sender.request.URL.String(), should.Equal, placeholderURL)
 	f.So(f.sender.request.Header.Get("Content-Type"), should.Equal, "application/json")
 

--- a/us-zipcode-api/lookup.go
+++ b/us-zipcode-api/lookup.go
@@ -1,7 +1,9 @@
 package zipcode
 
+import "net/url"
+
 // Lookup contains all input fields defined here:
-// https://smartystreets.com/docs/us-street-api#input-fields
+// https://smartystreets.com/docs/us-zipcode-api#input-fields
 type Lookup struct {
 	City    string `json:"city,omitempty"`
 	State   string `json:"state,omitempty"`
@@ -9,4 +11,17 @@ type Lookup struct {
 	InputID string `json:"input_id,omitempty"`
 
 	Result *Result `json:"-"`
+}
+
+func (l *Lookup) encodeQueryString(query url.Values) {
+	encode(query, l.City, "city")
+	encode(query, l.State, "state")
+	encode(query, l.ZIPCode, "zipcode")
+	encode(query, l.InputID, "input_id")
+}
+
+func encode(query url.Values, source string, target string) {
+	if source != "" {
+		query.Set(target, source)
+	}
 }

--- a/us-zipcode-api/lookup_test.go
+++ b/us-zipcode-api/lookup_test.go
@@ -1,0 +1,44 @@
+package zipcode
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/smartystreets/assertions/should"
+	"github.com/smartystreets/gunit"
+)
+
+func TestLookupFixture(t *testing.T) {
+	gunit.Run(new(LookupFixture), t)
+}
+
+type LookupFixture struct {
+	*gunit.Fixture
+}
+
+func (this *LookupFixture) encode(lookup *Lookup) url.Values {
+	var values = make(url.Values)
+	lookup.encodeQueryString(values)
+	return values
+}
+
+func (this *LookupFixture) TestQueryStringEncoding_OnlySerializeNonDefaultFields() {
+	this.So(this.encode(&Lookup{City: "A"}), should.Resemble, url.Values{"city": {"A"}})
+	this.So(this.encode(&Lookup{State: "A"}), should.Resemble, url.Values{"state": {"A"}})
+	this.So(this.encode(&Lookup{ZIPCode: "A"}), should.Resemble, url.Values{"zipcode": {"A"}})
+	this.So(this.encode(&Lookup{InputID: "A"}), should.Resemble, url.Values{"input_id": {"A"}})
+}
+
+func (this *LookupFixture) TestQueryStringEncoding_AllFieldsSerialized() {
+	this.So(this.encode(&Lookup{
+		InputID: "InputID",
+		ZIPCode: "ZIPCode",
+		City:    "City",
+		State:   "State",
+	}), should.Resemble, url.Values{
+		"input_id": {"InputID"},
+		"zipcode":  {"ZIPCode"},
+		"city":     {"City"},
+		"state":    {"State"},
+	})
+}


### PR DESCRIPTION
GET serialization did not include any parameters beyond ID, which made
lookups hard.  Now mirrors the structure of us-street-api, using
lookup.encodeQueryString.

Add to the client tests to ensure parameters are encoded correctly.