### PR TITLE
Use exponential backoff in retry client

### DIFF
--- a/internal/sdk/retry_client.go
+++ b/internal/sdk/retry_client.go
@@ -58,12 +58,23 @@ func (r *RetryClient) doBufferedPost(request *http.Request) (response *http.Resp
 }
 
 func (r *RetryClient) backOff(attempt int) bool {
+	if attempt == 0 {
+		return true
+	}
 	if attempt > r.maxRetries {
 		return false
 	}
-	backOff := time.Second * time.Duration(attempt)
-	r.sleeper.Sleep(minDuration(backOff, maxBackOffDuration))
+	backOffCap := min(maxBackOffDuration, 2<<attempt)
+	backOff := time.Second * time.Duration(rand.Intn(backOffCap))
+	r.sleeper.Sleep(backOff)
 	return true
+}
+
+func min(x, y int) int {
+	if x < y {
+		return x
+	}
+	return y
 }
 
 func minDuration(a, b time.Duration) time.Duration {
@@ -73,4 +84,4 @@ func minDuration(a, b time.Duration) time.Duration {
 	return b
 }
 
-const maxBackOffDuration = time.Second * 10
+const maxBackOffDuration = 120

--- a/internal/sdk/retry_client.go
+++ b/internal/sdk/retry_client.go
@@ -15,6 +15,7 @@ type RetryClient struct {
 	inner      HTTPClient
 	maxRetries int
 	sleeper    *clock.Sleeper
+	rand       *rand.Rand
 }
 
 func NewRetryClient(inner HTTPClient, maxRetries int) HTTPClient {
@@ -24,6 +25,7 @@ func NewRetryClient(inner HTTPClient, maxRetries int) HTTPClient {
 	return &RetryClient{
 		inner:      inner,
 		maxRetries: maxRetries,
+		rand: rand.New(rand.NewSource(0)),
 	}
 }
 
@@ -66,7 +68,7 @@ func (r *RetryClient) backOff(attempt int) bool {
 		return false
 	}
 	backOffCap := min(maxBackOffDuration, 2<<attempt)
-	backOff := time.Second * time.Duration(rand.Intn(backOffCap))
+	backOff := time.Second * time.Duration(r.rand.Intn(backOffCap))
 	r.sleeper.Sleep(backOff)
 	return true
 }

--- a/internal/sdk/retry_client.go
+++ b/internal/sdk/retry_client.go
@@ -3,6 +3,7 @@ package sdk
 import (
 	"bytes"
 	"io/ioutil"
+	"math/rand"
 	"net/http"
 	"time"
 

--- a/internal/sdk/retry_client.go
+++ b/internal/sdk/retry_client.go
@@ -85,4 +85,4 @@ func minDuration(a, b time.Duration) time.Duration {
 	return b
 }
 
-const maxBackOffDuration = 120
+const maxBackOffDuration = 10

--- a/internal/sdk/retry_client.go
+++ b/internal/sdk/retry_client.go
@@ -25,7 +25,7 @@ func NewRetryClient(inner HTTPClient, maxRetries int) HTTPClient {
 	return &RetryClient{
 		inner:      inner,
 		maxRetries: maxRetries,
-		rand: rand.New(rand.NewSource(0)),
+		rand:       rand.New(rand.NewSource(0)),
 	}
 }
 

--- a/internal/sdk/retry_client.go
+++ b/internal/sdk/retry_client.go
@@ -18,14 +18,14 @@ type RetryClient struct {
 	rand       *rand.Rand
 }
 
-func NewRetryClient(inner HTTPClient, maxRetries int) HTTPClient {
+func NewRetryClient(inner HTTPClient, maxRetries int, rand *rand.Rand) HTTPClient {
 	if maxRetries == 0 {
 		return inner
 	}
 	return &RetryClient{
 		inner:      inner,
 		maxRetries: maxRetries,
-		rand:       rand.New(rand.NewSource(0)),
+		rand:       rand,
 	}
 }
 

--- a/internal/sdk/retry_client_test.go
+++ b/internal/sdk/retry_client_test.go
@@ -127,9 +127,15 @@ func (f *RetryClientFixture) TestBackOffNeverToExceedHardCodedMaximum() {
 	f.So(f.inner.call, should.Equal, 20)
 	f.So(f.sleeper.Naps, should.Resemble,
 
-		[]time.Duration{time.Second * 2, time.Second * 2, time.Second * 3, time.Second * 6, time.Second * 5, time.Second * 6,
-			time.Second * 7, 7 * time.Second, 8 * time.Second, 8 * time.Second, 8 * time.Second, 7 * time.Second, 9 * time.Second,
-			8 * time.Second, 2 * time.Second, 6 * time.Second, 1 * time.Second, 0 * time.Second, 0 * time.Second})
+		[]time.Duration{
+			time.Second * 2, // randomly between 0-2
+			time.Second * 2, // randomlyl between 0-4
+			time.Second * 3, // randomly between 0-8
+			// the rest are randomly between 0-10 (capped)
+			6 * time.Second, 5 * time.Second, 6 * time.Second, 7 * time.Second,
+			7 * time.Second, 8 * time.Second, 8 * time.Second, 8 * time.Second,
+			7 * time.Second, 9 * time.Second, 8 * time.Second, 2 * time.Second,
+			6 * time.Second, 1 * time.Second, 0 * time.Second, 0 * time.Second})
 }
 
 /**************************************************************************/

--- a/internal/sdk/retry_client_test.go
+++ b/internal/sdk/retry_client_test.go
@@ -130,7 +130,7 @@ func (f *RetryClientFixture) TestBackOffNeverToExceedHardCodedMaximum() {
 
 		[]time.Duration{
 			time.Second * 2, // randomly between 0-2
-			time.Second * 2, // randomlyl between 0-4
+			time.Second * 2, // randomly between 0-4
 			time.Second * 3, // randomly between 0-8
 			// the rest are randomly between 0-10 (capped)
 			6 * time.Second, 5 * time.Second, 6 * time.Second, 7 * time.Second,

--- a/internal/sdk/retry_client_test.go
+++ b/internal/sdk/retry_client_test.go
@@ -77,7 +77,7 @@ func (f *RetryClientFixture) assertRequestWasSuccessful() {
 func (f *RetryClientFixture) assertBackOffStrategyWasObserved() {
 	f.So(f.inner.call, should.Equal, 5)
 	f.So(f.sleeper.Naps, should.Resemble,
-		[]time.Duration{time.Second * 0, time.Second * 1, time.Second * 2, time.Second * 3, time.Second * 4})
+		[]time.Duration{2 * time.Second, 2 * time.Second, 3 * time.Second, 6 * time.Second})
 }
 
 /**************************************************************************/
@@ -126,12 +126,10 @@ func (f *RetryClientFixture) TestBackOffNeverToExceedHardCodedMaximum() {
 	f.So(f.err, should.BeNil)
 	f.So(f.inner.call, should.Equal, 20)
 	f.So(f.sleeper.Naps, should.Resemble,
-		[]time.Duration{
-			time.Second * 0, time.Second * 1, time.Second * 2, time.Second * 3, time.Second * 4, // incrementing
-			time.Second * 5, time.Second * 6, time.Second * 7, time.Second * 8, time.Second * 9, // incrementing
-			time.Second * 10, time.Second * 10, time.Second * 10, time.Second * 10, time.Second * 10, // max backoff: 10s
-			time.Second * 10, time.Second * 10, time.Second * 10, time.Second * 10, time.Second * 10, // max backoff: 10s
-		})
+
+		[]time.Duration{time.Second * 2, time.Second * 2, time.Second * 3, time.Second * 6, time.Second * 5, time.Second * 6,
+			time.Second * 7, 7 * time.Second, 8 * time.Second, 8 * time.Second, 8 * time.Second, 7 * time.Second, 9 * time.Second,
+			8 * time.Second, 2 * time.Second, 6 * time.Second, 1 * time.Second, 0 * time.Second, 0 * time.Second})
 }
 
 /**************************************************************************/

--- a/internal/sdk/retry_client_test.go
+++ b/internal/sdk/retry_client_test.go
@@ -2,6 +2,7 @@ package sdk
 
 import (
 	"errors"
+	"math/rand"
 	"net/http"
 	"strings"
 	"testing"
@@ -35,7 +36,7 @@ func (f *RetryClientFixture) TestRequestBodyCannotBeBuffered_ErrorReturnedImmedi
 }
 func (f *RetryClientFixture) sendErrorProneRequest() (*http.Response, error) {
 	f.inner = &FakeMultiHTTPClient{}
-	client := NewRetryClient(f.inner, 10).(*RetryClient)
+	client := NewRetryClient(f.inner, 10, rand.New(rand.NewSource(0))).(*RetryClient)
 	client.sleeper = f.sleeper
 	request, _ := http.NewRequest("POST", "/", &ErrorProneReadCloser{readError: errors.New("GOPHERS!")})
 	return client.Do(request)
@@ -112,7 +113,7 @@ func (f *RetryClientFixture) assertInternalServerError() {
 
 func (f *RetryClientFixture) TestNoRetryRequestedReturnsInnerClientInstead() {
 	inner := &FakeHTTPClient{}
-	client := NewRetryClient(inner, 0)
+	client := NewRetryClient(inner, 0, rand.New(rand.NewSource(0)))
 	f.So(client, should.Equal, inner)
 }
 
@@ -141,13 +142,13 @@ func (f *RetryClientFixture) TestBackOffNeverToExceedHardCodedMaximum() {
 /**************************************************************************/
 
 func (f *RetryClientFixture) sendGetWithRetry(retries int) (*http.Response, error) {
-	client := NewRetryClient(f.inner, retries).(*RetryClient)
+	client := NewRetryClient(f.inner, retries, rand.New(rand.NewSource(0))).(*RetryClient)
 	client.sleeper = f.sleeper
 	request, _ := http.NewRequest("GET", "/?body=request", nil)
 	return client.Do(request)
 }
 func (f *RetryClientFixture) sendPostWithRetry(retries int) (*http.Response, error) {
-	client := NewRetryClient(f.inner, retries).(*RetryClient)
+	client := NewRetryClient(f.inner, retries, rand.New(rand.NewSource(0))).(*RetryClient)
 	client.sleeper = f.sleeper
 	request, _ := http.NewRequest("POST", "/", strings.NewReader("request"))
 	return client.Do(request)

--- a/wireup/builder.go
+++ b/wireup/builder.go
@@ -3,6 +3,7 @@ package wireup
 import (
 	"crypto/tls"
 	"fmt"
+	"math/rand"
 	"net/http"
 	"net/url"
 	"time"
@@ -164,7 +165,7 @@ func (b *clientBuilder) buildHTTPClient() (wrapped internal.HTTPClient) {
 	wrapped = b.buildClient()
 	wrapped = internal.NewTracingClient(wrapped, b.trace)
 	wrapped = internal.NewDebugOutputClient(wrapped, b.debug)
-	wrapped = internal.NewRetryClient(wrapped, b.retries)
+	wrapped = internal.NewRetryClient(wrapped, b.retries, rand.New(rand.NewSource(time.Now().UnixNano())))
 	wrapped = internal.NewSigningClient(wrapped, b.credential)
 	wrapped = internal.NewBaseURLClient(wrapped, b.baseURL)
 	wrapped = internal.NewCustomHeadersClient(wrapped, b.headers)


### PR DESCRIPTION
Addresses https://github.com/smartystreets/smartystreets-go-sdk/issues/17

Predictably, unit tests are failing. Before I fix them, I'd love to get feedback on this approach. Is it ok to just update the RetryClient, or would you prefer to add the ability to choose a backoff strategy etc? cc @mdwhatcott 

Thanks!