### PR TITLE
US Street API: support for new coordinate_license field

### DIFF
--- a/coordinate_license.go
+++ b/coordinate_license.go
@@ -1,0 +1,18 @@
+package sdk
+
+type CoordinateLicense uint16
+
+// CoordinateLicense values and associated details defined here: https://smartystreets.com/docs/cloud/us-reverse-geo-api#licenses
+const (
+	CoordinateLicenseSmartyStreets  CoordinateLicense = 0
+	CoordinateLicenseGatewaySpatial CoordinateLicense = 1
+)
+
+func (this CoordinateLicense) String() string {
+	switch this {
+	case CoordinateLicenseGatewaySpatial:
+		return "Gateway Spatial, LLC"
+	default:
+		return "SmartyStreets"
+	}
+}

--- a/coordinate_license_test.go
+++ b/coordinate_license_test.go
@@ -1,0 +1,22 @@
+package sdk
+
+import (
+	"testing"
+
+	"github.com/smartystreets/assertions/should"
+	"github.com/smartystreets/gunit"
+)
+
+func TestCoordinateLicenseFixture(t *testing.T) {
+	gunit.Run(new(CoordinateLicenseFixture), t)
+}
+
+type CoordinateLicenseFixture struct {
+	*gunit.Fixture
+}
+
+func (this *CoordinateLicenseFixture) TestLicenseString() {
+	this.So(CoordinateLicenseSmartyStreets.String(), should.Equal, "SmartyStreets")
+	this.So(CoordinateLicenseGatewaySpatial.String(), should.Equal, "Gateway Spatial, LLC")
+	this.So(CoordinateLicense(42).String(), should.Equal, "SmartyStreets")
+}

--- a/us-street-api/candidate.go
+++ b/us-street-api/candidate.go
@@ -1,5 +1,7 @@
 package street
 
+import sdk "github.com/smartystreets/smartystreets-go-sdk"
+
 type (
 	// Candidate contains all output fields defined here:
 	// https://smartystreets.com/docs/us-street-api#http-response-output
@@ -44,23 +46,24 @@ type (
 	// Metadata contains all output fields defined here:
 	// https://smartystreets.com/docs/us-street-api#metadata
 	Metadata struct {
-		RecordType               string  `json:"record_type,omitempty"`
-		ZIPType                  string  `json:"zip_type,omitempty"`
-		CountyFIPS               string  `json:"county_fips,omitempty"`
-		CountyName               string  `json:"county_name,omitempty"`
-		CarrierRoute             string  `json:"carrier_route,omitempty"`
-		CongressionalDistrict    string  `json:"congressional_district,omitempty"`
-		BuildingDefaultIndicator string  `json:"building_default_indicator,omitempty"`
-		RDI                      string  `json:"rdi,omitempty"`
-		ELOTSequence             string  `json:"elot_sequence,omitempty"`
-		ELOTSort                 string  `json:"elot_sort,omitempty"`
-		Latitude                 float64 `json:"latitude,omitempty"`
-		Longitude                float64 `json:"longitude,omitempty"`
-		Precision                string  `json:"precision,omitempty"`
-		TimeZone                 string  `json:"time_zone,omitempty"`
-		UTCOffset                float32 `json:"utc_offset,omitempty"`
-		DST                      bool    `json:"dst,omitempty"`
-		EWSMatch                 bool    `json:"ews_match,omitempty"`
+		RecordType               string                `json:"record_type,omitempty"`
+		ZIPType                  string                `json:"zip_type,omitempty"`
+		CountyFIPS               string                `json:"county_fips,omitempty"`
+		CountyName               string                `json:"county_name,omitempty"`
+		CarrierRoute             string                `json:"carrier_route,omitempty"`
+		CongressionalDistrict    string                `json:"congressional_district,omitempty"`
+		BuildingDefaultIndicator string                `json:"building_default_indicator,omitempty"`
+		RDI                      string                `json:"rdi,omitempty"`
+		ELOTSequence             string                `json:"elot_sequence,omitempty"`
+		ELOTSort                 string                `json:"elot_sort,omitempty"`
+		Latitude                 float64               `json:"latitude,omitempty"`
+		Longitude                float64               `json:"longitude,omitempty"`
+		CoordinateLicense        sdk.CoordinateLicense `json:"coordinate_license,omitempty"`
+		Precision                string                `json:"precision,omitempty"`
+		TimeZone                 string                `json:"time_zone,omitempty"`
+		UTCOffset                float32               `json:"utc_offset,omitempty"`
+		DST                      bool                  `json:"dst,omitempty"`
+		EWSMatch                 bool                  `json:"ews_match,omitempty"`
 	}
 
 	// Analysis contains all output fields defined here:

--- a/us-street-api/client_test.go
+++ b/us-street-api/client_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/smartystreets/assertions/should"
 	"github.com/smartystreets/gunit"
+	sdk "github.com/smartystreets/smartystreets-go-sdk"
 )
 
 func TestClientFixture(t *testing.T) {
@@ -178,7 +179,8 @@ func (f *ClientFixture) TestFullJSONResponseDeserialization() {
       "elot_sort": "A",
       "latitude": 40.27658,
       "longitude": -111.65759,
-      "precision": "Zip9",
+      "coordinate_license": 1,
+      "precision": "Rooftop",
       "time_zone": "Mountain",
       "utc_offset": -7,
       "dst": true,
@@ -245,7 +247,8 @@ func (f *ClientFixture) TestFullJSONResponseDeserialization() {
 				ELOTSort:                 "A",
 				Latitude:                 40.27658,
 				Longitude:                -111.65759,
-				Precision:                "Zip9",
+				CoordinateLicense:        sdk.CoordinateLicenseGatewaySpatial,
+				Precision:                "Rooftop",
 				TimeZone:                 "Mountain",
 				UTCOffset:                -7,
 				DST:                      true,


### PR DESCRIPTION
Introduced in US Street API version 4.4.0:

https://github.com/smartystreets/changelog/blob/master/cloud/us-street-api.md#440---2020-09-09