### PR TITLE
Remove option KeepTryingOnRateLimit introduced in v1.14.0 which is no…

### DIFF
--- a/us-extract-api/lookup.go
+++ b/us-extract-api/lookup.go
@@ -10,14 +10,12 @@ import (
 // Lookup represents all input fields documented here:
 // https://smartystreets.com/docs/cloud/us-extract-api#http-request-input-fields
 type Lookup struct {
-	Text string
-
-	HTML                    HTMLPayload
-	Aggressive              bool
-	AddressesWithLineBreaks bool
-	AddressesPerLine        int
-
-	Result *Result
+	Text                    string      `json:"text,omitempty"`
+	HTML                    HTMLPayload `json:"html,omitempty"`
+	Aggressive              bool        `json:"aggressive,omitempty"`
+	AddressesWithLineBreaks bool        `json:"addr_line_breaks,omitempty"`
+	AddressesPerLine        int         `json:"addr_per_line,omitempty"`
+	Result                  *Result     `json:"result,omitempty"`
 }
 
 type HTMLPayload string

--- a/us-zipcode-api/lookup.go
+++ b/us-zipcode-api/lookup.go
@@ -10,7 +10,7 @@ type Lookup struct {
 	ZIPCode string `json:"zipcode,omitempty"`
 	InputID string `json:"input_id,omitempty"`
 
-	Result *Result `json:"-"`
+	Result *Result `json:"result,omitempty"`
 }
 
 func (l *Lookup) encodeQueryString(query url.Values) {

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package sdk
 
-const VERSION = "v1.14.11"
+const VERSION = "v1.15.0"

--- a/wireup/options.go
+++ b/wireup/options.go
@@ -183,11 +183,3 @@ func WithLicenses(licenses ...string) Option {
 		builder.licenses = append(builder.licenses, licenses...)
 	}
 }
-
-// KeepTryingOnRateLimit will continue trying until the caller is within the bounds of their rate limit.
-// Deprecated: no longer used
-func KeepTryingOnRateLimit() Option {
-	return func(builder *clientBuilder) {
-		builder.withMaxRetry(20)
-	}
-}


### PR DESCRIPTION
Removed Option `KeepTryingOnRateLimit` (added in `v1.14.0`) as it is no longer used for rate limit handling since `v1.14.4`.