### PR TITLE
Autocomplete-pro add Selected to lookup

### DIFF
--- a/us-autocomplete-pro-api/lookup.go
+++ b/us-autocomplete-pro-api/lookup.go
@@ -120,6 +120,6 @@ func (l Lookup) populateSource(query url.Values) {
 }
 func (l Lookup) populateSelect(query url.Values) {
 	if len(l.Select) > 0 {
-		query.Set("select", l.Source)
+		query.Set("select", l.Select)
 	}
 }

--- a/us-autocomplete-pro-api/lookup.go
+++ b/us-autocomplete-pro-api/lookup.go
@@ -22,6 +22,7 @@ type (
 		PreferZIP     []string
 		PreferRatio   int
 		Geolocation   Geolocation
+		Select        string
 
 		Results []*Suggestion
 	}
@@ -46,6 +47,7 @@ func (l Lookup) populate(query url.Values) {
 	l.populatePreferRatio(query)
 	l.populateGeolocation(query)
 	l.populateSource(query)
+	l.populateSelect(query)
 }
 
 func (l Lookup) populateSearch(query url.Values) {
@@ -114,5 +116,10 @@ func (l Lookup) populateGeolocation(query url.Values) {
 func (l Lookup) populateSource(query url.Values) {
 	if len(l.Source) > 0 {
 		query.Set("source", l.Source)
+	}
+}
+func (l Lookup) populateSelect(query url.Values) {
+	if len(l.Select) > 0 {
+		query.Set("select", l.Source)
 	}
 }

--- a/us-autocomplete-pro-api/lookup.go
+++ b/us-autocomplete-pro-api/lookup.go
@@ -22,7 +22,7 @@ type (
 		PreferZIP     []string
 		PreferRatio   int
 		Geolocation   Geolocation
-		Select        string
+		Selected      string
 
 		Results []*Suggestion
 	}
@@ -47,7 +47,7 @@ func (l Lookup) populate(query url.Values) {
 	l.populatePreferRatio(query)
 	l.populateGeolocation(query)
 	l.populateSource(query)
-	l.populateSelect(query)
+	l.populateSelected(query)
 }
 
 func (l Lookup) populateSearch(query url.Values) {
@@ -118,8 +118,8 @@ func (l Lookup) populateSource(query url.Values) {
 		query.Set("source", l.Source)
 	}
 }
-func (l Lookup) populateSelect(query url.Values) {
-	if len(l.Select) > 0 {
-		query.Set("select", l.Select)
+func (l Lookup) populateSelected(query url.Values) {
+	if len(l.Selected) > 0 {
+		query.Set("selected", l.Selected)
 	}
 }

--- a/us-autocomplete-pro-api/lookup_test.go
+++ b/us-autocomplete-pro-api/lookup_test.go
@@ -149,7 +149,7 @@ func (f *LookupSerializationFixture) TestGeolocateCity_DefaultValue() {
 }
 
 func (f *LookupSerializationFixture) TestSelect() {
-	f.lookup.Select = "Hello World!"
+	f.lookup.Selected = "Hello World!"
 
 	f.populate()
 

--- a/us-autocomplete-pro-api/lookup_test.go
+++ b/us-autocomplete-pro-api/lookup_test.go
@@ -147,3 +147,12 @@ func (f *LookupSerializationFixture) TestGeolocateCity_DefaultValue() {
 	f.So(f.query, should.HaveLength, 1)
 	f.So(f.query.Get("prefer_geolocation"), should.Equal, "city")
 }
+
+func (f *LookupSerializationFixture) TestSelect() {
+	f.lookup.Select = "Hello World!"
+
+	f.populate()
+
+	f.So(f.query, should.HaveLength, 1)
+	f.So(f.query.Get("select"), should.Equal, "Hello World!")
+}


### PR DESCRIPTION
The lookup for us-autocomplete-pro is missing the selected field. 
This pull request adds the selected field to the lookup struct, the populate method needed, and test to check if the populate method for selected it correct.
I have also tested the sdk in a different project with the changes made and it works as expected.