### PR TITLE
Generic Enrichment Lookups

### DIFF
--- a/examples/us-enrichment-api/universal/main.go
+++ b/examples/us-enrichment-api/universal/main.go
@@ -35,7 +35,7 @@ func main() {
 		ETag:      "",                           // optional: check if the record has been updated
 	}
 
-	err, results := client.SendPropertyPrincipal(&lookup)
+	err, results := client.SendUniversalLookup(&lookup, "property", "principal") //for datasets with no subsets, enter the empty string, "", for the dataSubset field
 
 	if err != nil {
 		// If ETag was supplied in the lookup, this status will be returned if the ETag value for the record is current
@@ -47,11 +47,7 @@ func main() {
 	}
 
 	fmt.Printf("Results for input: (%s, %s)\n", smartyKey, "principal")
-	for s, response := range results {
-		fmt.Printf("#%d: %+v\n", s, response)
-	}
-
-	//TODO: Add a test for the "genericLookup" feature
+	fmt.Println(string(results))
 
 	log.Println("OK")
 }

--- a/us-enrichment-api/client.go
+++ b/us-enrichment-api/client.go
@@ -2,7 +2,6 @@ package us_enrichment
 
 import (
 	"context"
-	"encoding/json"
 	"net/http"
 	"strings"
 
@@ -38,15 +37,14 @@ func (c *Client) SendPropertyPrincipal(lookup *Lookup) (error, []*PrincipalRespo
 }
 
 func (c *Client) SendGenericLookup(lookup *Lookup, dataSet, dataSubset string) (error, []byte) {
-	propertyLookup := &genericLookup{
+	g := &genericLookup{
 		Lookup:     lookup,
 		DataSet:    dataSet,
 		DataSubset: dataSubset,
 	}
 
-	err := c.sendLookup(propertyLookup)
-	jsonData, _ := json.Marshal(propertyLookup.Response)
-	return err, jsonData
+	err := c.sendLookup(g)
+	return err, g.Response
 }
 
 func (c *Client) sendLookup(lookup enrichmentLookup) error {

--- a/us-enrichment-api/client.go
+++ b/us-enrichment-api/client.go
@@ -36,8 +36,8 @@ func (c *Client) SendPropertyPrincipal(lookup *Lookup) (error, []*PrincipalRespo
 	return err, propertyLookup.Response
 }
 
-func (c *Client) SendGenericLookup(lookup *Lookup, dataSet, dataSubset string) (error, []byte) {
-	g := &genericLookup{
+func (c *Client) SendUniversalLookup(lookup *Lookup, dataSet, dataSubset string) (error, []byte) {
+	g := &universalLookup{
 		Lookup:     lookup,
 		DataSet:    dataSet,
 		DataSubset: dataSubset,

--- a/us-enrichment-api/client_test.go
+++ b/us-enrichment-api/client_test.go
@@ -93,6 +93,29 @@ func (f *ClientFixture) TestDeserializationErrorPreventsDeserialization() {
 	f.So(f.input.(*principalLookup).Response, should.BeEmpty)
 }
 
+func (f *ClientFixture) TestGenericLookupUnmarshallingWithEtag() {
+	lookup := genericLookup{
+		Response: []byte(validFinancialResponse),
+	}
+	httpHeaders := http.Header{"Etag": []string{"ABCDEFG"}}
+
+	_ = lookup.unmarshalResponse(lookup.Response, httpHeaders)
+
+	f.So(lookup.Response, should.Equal, []byte(`[{"eTag": "ABCDEFG","smarty_key":"123","data_set_name":"property","data_subset_name":"financial","attributes":{"assessed_improvement_percent":"Assessed_Improvement_Percent","veteran_tax_exemption":"Veteran_Tax_Exemption","widow_tax_exemption":"Widow_Tax_Exemption"}}]`))
+}
+
+func (f *ClientFixture) TestGenericLookupUnmarshallingWithNoEtag() {
+	lookup := genericLookup{
+		Response: []byte(validPrincipalResponse),
+	}
+
+	httpHeaders := http.Header{"NotAnEtag": []string{"ABC"}}
+
+	_ = lookup.unmarshalResponse(lookup.Response, httpHeaders)
+
+	f.So(lookup.Response, should.Equal, []byte(validPrincipalResponse))
+}
+
 var validFinancialResponse = `[{"smarty_key":"123","data_set_name":"property","data_subset_name":"financial","attributes":{"assessed_improvement_percent":"Assessed_Improvement_Percent","veteran_tax_exemption":"Veteran_Tax_Exemption","widow_tax_exemption":"Widow_Tax_Exemption"}}]`
 var validPrincipalResponse = `[{"smarty_key":"123","data_set_name":"property","data_subset_name":"principal","attributes":{"1st_floor_sqft":"1st_Floor_Sqft",lender_name_2":"Lender_Name_2","lender_seller_carry_back":"Lender_Seller_Carry_Back","year_built":"Year_Built","zoning":"Zoning"}}]`
 

--- a/us-enrichment-api/lookup.go
+++ b/us-enrichment-api/lookup.go
@@ -24,19 +24,19 @@ type enrichmentLookup interface {
 	populate(query url.Values)
 }
 
-type genericLookup struct {
+type universalLookup struct {
 	Lookup     *Lookup
 	DataSet    string
 	DataSubset string
 	Response   []byte
 }
 
-func (g *genericLookup) getSmartyKey() string     { return g.Lookup.SmartyKey }
-func (g *genericLookup) getDataSet() string       { return g.DataSet }
-func (g *genericLookup) getDataSubset() string    { return g.DataSubset }
-func (g *genericLookup) getLookup() *Lookup       { return g.Lookup }
-func (g *genericLookup) getResponse() interface{} { return g.Response }
-func (g *genericLookup) unmarshalResponse(bytes []byte, headers http.Header) error {
+func (g *universalLookup) getSmartyKey() string     { return g.Lookup.SmartyKey }
+func (g *universalLookup) getDataSet() string       { return g.DataSet }
+func (g *universalLookup) getDataSubset() string    { return g.DataSubset }
+func (g *universalLookup) getLookup() *Lookup       { return g.Lookup }
+func (g *universalLookup) getResponse() interface{} { return g.Response }
+func (g *universalLookup) unmarshalResponse(bytes []byte, headers http.Header) error {
 	g.Response = bytes
 	if headers != nil {
 		if etag, found := headers[lookupETagHeader]; found && len(etag) > 0 {
@@ -58,7 +58,7 @@ func (g *genericLookup) unmarshalResponse(bytes []byte, headers http.Header) err
 	return nil
 
 }
-func (g *genericLookup) populate(query url.Values) {
+func (g *universalLookup) populate(query url.Values) {
 	g.Lookup.populateInclude(query)
 	g.Lookup.populateExclude(query)
 }

--- a/us-enrichment-api/lookup.go
+++ b/us-enrichment-api/lookup.go
@@ -1,7 +1,7 @@
 package us_enrichment
 
 import (
-	"bytes"
+	bytesPackage "bytes"
 	"encoding/json"
 	"net/http"
 	"net/url"
@@ -36,19 +36,19 @@ func (g *genericLookup) getDataSet() string       { return g.DataSet }
 func (g *genericLookup) getDataSubset() string    { return g.DataSubset }
 func (g *genericLookup) getLookup() *Lookup       { return g.Lookup }
 func (g *genericLookup) getResponse() interface{} { return g.Response }
-func (g *genericLookup) unmarshalResponse(bytesResponse []byte, headers http.Header) error {
-	g.Response = bytesResponse
+func (g *genericLookup) unmarshalResponse(bytes []byte, headers http.Header) error {
+	g.Response = bytes
 	if headers != nil {
 		if etag, found := headers[lookupETagHeader]; found && len(etag) > 0 {
 
 			eTagAttribute := []byte(`"eTag": "` + etag[0] + `",`)
-			insertLocation := bytes.IndexByte(bytesResponse, '{') + 1
+			insertLocation := bytesPackage.IndexByte(bytes, '{') + 1
 
-			if insertLocation > 0 && insertLocation < len(bytesResponse) {
-				var modifiedResponse bytes.Buffer
-				modifiedResponse.Write(bytesResponse[:insertLocation])
+			if insertLocation > 0 && insertLocation < len(bytes) {
+				var modifiedResponse bytesPackage.Buffer
+				modifiedResponse.Write(bytes[:insertLocation])
 				modifiedResponse.Write(eTagAttribute)
-				modifiedResponse.Write(bytesResponse[insertLocation:])
+				modifiedResponse.Write(bytes[insertLocation:])
 				g.Response = modifiedResponse.Bytes()
 			}
 

--- a/us-enrichment-api/lookup.go
+++ b/us-enrichment-api/lookup.go
@@ -23,6 +23,39 @@ type enrichmentLookup interface {
 	populate(query url.Values)
 }
 
+type genericLookup struct {
+	Lookup     *Lookup
+	DataSet    string
+	DataSubset string
+	Response   []map[string]interface{}
+}
+
+func (g *genericLookup) getSmartyKey() string     { return g.Lookup.SmartyKey }
+func (g *genericLookup) getDataSet() string       { return g.DataSet }
+func (g *genericLookup) getDataSubset() string    { return g.DataSubset }
+func (g *genericLookup) getLookup() *Lookup       { return g.Lookup }
+func (g *genericLookup) getResponse() interface{} { return g.Response }
+func (g *genericLookup) unmarshalResponse(bytes []byte, headers http.Header) error {
+	if err := json.Unmarshal(bytes, &g.Response); err != nil {
+		return err
+	}
+
+	if headers != nil {
+		if etag, found := headers[lookupETagHeader]; found {
+			if len(etag) > 0 && len(g.Response) > 0 {
+				g.Response[0]["eTag"] = etag[0]
+			}
+		}
+	}
+
+	return nil
+
+}
+func (g *genericLookup) populate(query url.Values) {
+	g.Lookup.populateInclude(query)
+	g.Lookup.populateExclude(query)
+}
+
 ////////////////////////////////////////////////////////////////////////////////////////
 
 type financialLookup struct {


### PR DESCRIPTION
Added functionality to the us-enrichment-api to allow for generic lookups that return raw json as a byte slice. This will allow for future data sets to be added without needing to make an immediate change to the SDK. 