### PR TITLE
Enabling Search for enrichment lookups

### DIFF
--- a/us-enrichment-api/client.go
+++ b/us-enrichment-api/client.go
@@ -109,13 +109,21 @@ func buildRequest(lookup enrichmentLookup) *http.Request {
 func buildLookupURL(lookup enrichmentLookup) string {
 	var newLookupURL string
 	if len(lookup.getDataSubset()) == 0 {
-		newLookupURL = strings.Replace(lookupURLWithoutSubSet, lookupURLSmartyKey, lookup.getSmartyKey(), 1)
+		newLookupURL = strings.Replace(lookupURLWithoutSubSet, lookupURLSmartyKey, getLookupURLSmartyKeyReplacement(lookup), 1)
 	} else {
-		newLookupURL = strings.Replace(lookupURLWithSubSet, lookupURLSmartyKey, lookup.getSmartyKey(), 1)
+		newLookupURL = strings.Replace(lookupURLWithSubSet, lookupURLSmartyKey, getLookupURLSmartyKeyReplacement(lookup), 1)
 	}
 
 	newLookupURL = strings.Replace(newLookupURL, lookupURLDataSet, lookup.getDataSet(), 1)
 	return strings.TrimSuffix(strings.Replace(newLookupURL, lookupURLDataSubSet, lookup.getDataSubset(), 1), "/")
+}
+
+func getLookupURLSmartyKeyReplacement(lookup enrichmentLookup) string {
+	if len(lookup.getSmartyKey()) > 0 {
+		return lookup.getSmartyKey()
+	} else {
+		return addressSearch
+	}
 }
 
 const (
@@ -125,4 +133,5 @@ const (
 	lookupURLWithSubSet    = "/lookup/" + lookupURLSmartyKey + "/" + lookupURLDataSet + "/" + lookupURLDataSubSet // Remaining parts will be completed later by the sdk.BaseURLClient.
 	lookupURLWithoutSubSet = "/lookup/" + lookupURLSmartyKey + "/" + lookupURLDataSet                             // Remaining parts will be completed later by the sdk.BaseURLClient.
 	lookupETagHeader       = "Etag"
+	addressSearch          = "search"
 )

--- a/us-enrichment-api/client.go
+++ b/us-enrichment-api/client.go
@@ -73,9 +73,6 @@ func (c *Client) sendLookupWithContext(ctx context.Context, lookup enrichmentLoo
 	if lookup == nil || lookup.getLookup() == nil {
 		return nil
 	}
-	if len(lookup.getSmartyKey()) == 0 {
-		return nil
-	}
 
 	request := buildRequest(lookup)
 	request = request.WithContext(ctx)

--- a/us-enrichment-api/lookup.go
+++ b/us-enrichment-api/lookup.go
@@ -37,9 +37,6 @@ type universalLookup struct {
 }
 
 func (g *universalLookup) getSmartyKey() string {
-	if len(g.Lookup.SmartyKey) == 0 {
-		return addressSearch
-	}
 	return g.Lookup.SmartyKey
 }
 func (g *universalLookup) getDataSet() string       { return g.DataSet }
@@ -87,9 +84,6 @@ type financialLookup struct {
 }
 
 func (f *financialLookup) getSmartyKey() string {
-	if len(f.Lookup.SmartyKey) == 0 {
-		return addressSearch
-	}
 	return f.Lookup.SmartyKey
 }
 
@@ -143,9 +137,6 @@ type principalLookup struct {
 }
 
 func (p *principalLookup) getSmartyKey() string {
-	if len(p.Lookup.SmartyKey) == 0 {
-		return addressSearch
-	}
 	return p.Lookup.SmartyKey
 }
 
@@ -213,9 +204,6 @@ func (g *geoReferenceLookup) populate(query url.Values) {
 }
 
 func (g *geoReferenceLookup) getSmartyKey() string {
-	if len(g.Lookup.SmartyKey) == 0 {
-		return addressSearch
-	}
 	return g.Lookup.SmartyKey
 }
 
@@ -255,9 +243,6 @@ type secondaryLookup struct {
 }
 
 func (s *secondaryLookup) getSmartyKey() string {
-	if len(s.Lookup.SmartyKey) == 0 {
-		return addressSearch
-	}
 	return s.SmartyKey
 }
 
@@ -311,9 +296,6 @@ type secondaryCountLookup struct {
 }
 
 func (s *secondaryCountLookup) getSmartyKey() string {
-	if len(s.Lookup.SmartyKey) == 0 {
-		return addressSearch
-	}
 	return s.SmartyKey
 }
 
@@ -367,7 +349,6 @@ const (
 	secondaryData       = "secondary"
 	secondaryDataCount  = "count"
 	emptyDataSubset     = ""
-	addressSearch       = "search"
 )
 
 func (l Lookup) populateInclude(query url.Values) {

--- a/us-enrichment-api/lookup.go
+++ b/us-enrichment-api/lookup.go
@@ -38,7 +38,7 @@ type universalLookup struct {
 
 func (g *universalLookup) getSmartyKey() string {
 	if len(g.Lookup.SmartyKey) == 0 {
-		return smartyKeyBypass
+		return addressSearch
 	}
 	return g.Lookup.SmartyKey
 }
@@ -88,7 +88,7 @@ type financialLookup struct {
 
 func (f *financialLookup) getSmartyKey() string {
 	if len(f.Lookup.SmartyKey) == 0 {
-		return smartyKeyBypass
+		return addressSearch
 	}
 	return f.Lookup.SmartyKey
 }
@@ -144,7 +144,7 @@ type principalLookup struct {
 
 func (p *principalLookup) getSmartyKey() string {
 	if len(p.Lookup.SmartyKey) == 0 {
-		return smartyKeyBypass
+		return addressSearch
 	}
 	return p.Lookup.SmartyKey
 }
@@ -214,7 +214,7 @@ func (g *geoReferenceLookup) populate(query url.Values) {
 
 func (g *geoReferenceLookup) getSmartyKey() string {
 	if len(g.Lookup.SmartyKey) == 0 {
-		return smartyKeyBypass
+		return addressSearch
 	}
 	return g.Lookup.SmartyKey
 }
@@ -256,7 +256,7 @@ type secondaryLookup struct {
 
 func (s *secondaryLookup) getSmartyKey() string {
 	if len(s.Lookup.SmartyKey) == 0 {
-		return smartyKeyBypass
+		return addressSearch
 	}
 	return s.SmartyKey
 }
@@ -312,7 +312,7 @@ type secondaryCountLookup struct {
 
 func (s *secondaryCountLookup) getSmartyKey() string {
 	if len(s.Lookup.SmartyKey) == 0 {
-		return smartyKeyBypass
+		return addressSearch
 	}
 	return s.SmartyKey
 }
@@ -367,7 +367,7 @@ const (
 	secondaryData       = "secondary"
 	secondaryDataCount  = "count"
 	emptyDataSubset     = ""
-	smartyKeyBypass     = "search"
+	addressSearch       = "search"
 )
 
 func (l Lookup) populateInclude(query url.Values) {

--- a/us-enrichment-api/lookup.go
+++ b/us-enrichment-api/lookup.go
@@ -36,7 +36,12 @@ type universalLookup struct {
 	Response   []byte
 }
 
-func (g *universalLookup) getSmartyKey() string     { return g.Lookup.SmartyKey }
+func (g *universalLookup) getSmartyKey() string {
+	if len(g.Lookup.SmartyKey) == 0 {
+		return smartyKeyBypass
+	}
+	return g.Lookup.SmartyKey
+}
 func (g *universalLookup) getDataSet() string       { return g.DataSet }
 func (g *universalLookup) getDataSubset() string    { return g.DataSubset }
 func (g *universalLookup) getLookup() *Lookup       { return g.Lookup }
@@ -82,6 +87,9 @@ type financialLookup struct {
 }
 
 func (f *financialLookup) getSmartyKey() string {
+	if len(f.Lookup.SmartyKey) == 0 {
+		return smartyKeyBypass
+	}
 	return f.Lookup.SmartyKey
 }
 
@@ -135,6 +143,9 @@ type principalLookup struct {
 }
 
 func (p *principalLookup) getSmartyKey() string {
+	if len(p.Lookup.SmartyKey) == 0 {
+		return smartyKeyBypass
+	}
 	return p.Lookup.SmartyKey
 }
 
@@ -202,6 +213,9 @@ func (g *geoReferenceLookup) populate(query url.Values) {
 }
 
 func (g *geoReferenceLookup) getSmartyKey() string {
+	if len(g.Lookup.SmartyKey) == 0 {
+		return smartyKeyBypass
+	}
 	return g.Lookup.SmartyKey
 }
 
@@ -241,6 +255,9 @@ type secondaryLookup struct {
 }
 
 func (s *secondaryLookup) getSmartyKey() string {
+	if len(s.Lookup.SmartyKey) == 0 {
+		return smartyKeyBypass
+	}
 	return s.SmartyKey
 }
 
@@ -294,6 +311,9 @@ type secondaryCountLookup struct {
 }
 
 func (s *secondaryCountLookup) getSmartyKey() string {
+	if len(s.Lookup.SmartyKey) == 0 {
+		return smartyKeyBypass
+	}
 	return s.SmartyKey
 }
 
@@ -347,6 +367,7 @@ const (
 	secondaryData       = "secondary"
 	secondaryDataCount  = "count"
 	emptyDataSubset     = ""
+	smartyKeyBypass     = "search"
 )
 
 func (l Lookup) populateInclude(query url.Values) {


### PR DESCRIPTION
Introduce the smartyKeyBypass to enable non-smarty-key based searches.

Before, if SmartyKey® was not provided, the SDK would just return a nil response. 