### PR TITLE
Ryan/auth

### DIFF
--- a/basicauth_credential.go
+++ b/basicauth_credential.go
@@ -12,7 +12,7 @@ type basicAuthCredential struct {
 	authToken string
 }
 
-func NewBasicAuthCredential(authID, authToken string) *basicAuthCredential {
+func NewBasicAuthCredential(authID, authToken string) Credential {
 	if len(authID) == 0 || len(authToken) == 0 {
 		panic(ErrCredentialsRequired)
 	}

--- a/basicauth_credential_test.go
+++ b/basicauth_credential_test.go
@@ -20,8 +20,12 @@ func (this *BasicAuthCredentialFixture) TestNewBasicAuthCredentialWithValidCrede
 	cred := NewBasicAuthCredential("testID", "testToken")
 
 	this.So(cred, should.NotBeNil)
-	this.So(cred.authID, should.Equal, "testID")
-	this.So(cred.authToken, should.Equal, "testToken")
+	req, _ := http.NewRequest("GET", "http://example.com", nil)
+	cred.Sign(req)
+	username, password, ok := req.BasicAuth()
+	this.So(ok, should.BeTrue)
+	this.So(username, should.Equal, "testID")
+	this.So(password, should.Equal, "testToken")
 }
 
 func (this *BasicAuthCredentialFixture) TestNewBasicAuthCredentialWithEmptyAuthID() {
@@ -40,8 +44,12 @@ func (this *BasicAuthCredentialFixture) TestNewBasicAuthCredentialWithSpecialCha
 	cred := NewBasicAuthCredential("test@id#123", "token!@#$%^&*()")
 
 	this.So(cred, should.NotBeNil)
-	this.So(cred.authID, should.Equal, "test@id#123")
-	this.So(cred.authToken, should.Equal, "token!@#$%^&*()")
+	req, _ := http.NewRequest("GET", "http://example.com", nil)
+	cred.Sign(req)
+	username, password, ok := req.BasicAuth()
+	this.So(ok, should.BeTrue)
+	this.So(username, should.Equal, "test@id#123")
+	this.So(password, should.Equal, "token!@#$%^&*()")
 }
 
 func (this *BasicAuthCredentialFixture) TestSignWithValidCredentials() {

--- a/fake_credential_test_helper.go
+++ b/fake_credential_test_helper.go
@@ -1,0 +1,13 @@
+package sdk
+
+import "net/http"
+
+// FakeCredential is a test helper that implements Credential.
+// It returns the configured error from Sign without modifying the request.
+type FakeCredential struct {
+	Err error
+}
+
+func (f *FakeCredential) Sign(*http.Request) error {
+	return f.Err
+}

--- a/international-postal-code-api/client.go
+++ b/international-postal-code-api/client.go
@@ -49,7 +49,9 @@ func (c *Client) SendLookupWithContextAndAuth(ctx context.Context, lookup *Looku
 	request := buildRequest(lookup)
 	request = request.WithContext(ctx)
 	if credential != nil {
-		credential.Sign(request)
+		if err := credential.Sign(request); err != nil {
+			return err
+		}
 	}
 	response, err := c.sender.Send(request)
 	if err != nil {

--- a/international-postal-code-api/client.go
+++ b/international-postal-code-api/client.go
@@ -39,17 +39,17 @@ func (c *Client) SendLookupWithContext(ctx context.Context, lookup *Lookup) erro
 }
 
 // SendLookupWithContextAndAuth sends a lookup with the provided context and per-request credentials.
-// If authID and authToken are both non-empty, they will be used for this request instead of the client-level credentials.
+// If credential is non-nil, it will be used to sign this request instead of the client-level credentials.
 // This is useful for multi-tenant scenarios where different requests require different credentials.
-func (c *Client) SendLookupWithContextAndAuth(ctx context.Context, lookup *Lookup, authID, authToken string) error {
+func (c *Client) SendLookupWithContextAndAuth(ctx context.Context, lookup *Lookup, credential sdk.Credential) error {
 	if lookup == nil {
 		return errors.New("lookup cannot be nil")
 	}
 
 	request := buildRequest(lookup)
 	request = request.WithContext(ctx)
-	if len(authID) > 0 && len(authToken) > 0 {
-		request.SetBasicAuth(authID, authToken)
+	if credential != nil {
+		credential.Sign(request)
 	}
 	response, err := c.sender.Send(request)
 	if err != nil {

--- a/international-postal-code-api/client_test.go
+++ b/international-postal-code-api/client_test.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/smarty/assertions/should"
 	"github.com/smarty/gunit"
+
+	sdk "github.com/smartystreets/smartystreets-go-sdk"
 )
 
 func TestClientFixture(t *testing.T) {
@@ -118,6 +120,33 @@ func (f *ClientFixture) TestFullJSONResponseDeserialization() {
 	f.So(candidate.SuperAdministrativeArea, should.Equal, "6")
 	f.So(candidate.PostalCode, should.Equal, "7")
 	f.So(candidate.Thoroughfare, should.Equal, "8")
+}
+
+func (f *ClientFixture) TestSendLookupWithContextAndAuth_CredentialSignsRequest() {
+	f.sender.response = `[{"input_id": "1"}]`
+	f.input.Locality = "HI"
+	ctx := context.WithValue(context.Background(), "key", "value")
+
+	err := f.client.SendLookupWithContextAndAuth(ctx, f.input, sdk.NewSecretKeyCredential("myAuthID", "myAuthToken"))
+
+	f.So(err, should.BeNil)
+	f.So(f.sender.request, should.NotBeNil)
+	f.So(f.sender.request.Context(), should.Equal, ctx)
+	f.So(f.sender.request.URL.Query().Get("auth-id"), should.Equal, "myAuthID")
+	f.So(f.sender.request.URL.Query().Get("auth-token"), should.Equal, "myAuthToken")
+}
+
+func (f *ClientFixture) TestSendLookupWithContextAndAuth_NilCredentialDoesNotSign() {
+	f.sender.response = `[{"input_id": "1"}]`
+	f.input.Locality = "HI"
+	ctx := context.Background()
+
+	err := f.client.SendLookupWithContextAndAuth(ctx, f.input, nil)
+
+	f.So(err, should.BeNil)
+	f.So(f.sender.request, should.NotBeNil)
+	f.So(f.sender.request.URL.Query().Get("auth-id"), should.BeEmpty)
+	f.So(f.sender.request.URL.Query().Get("auth-token"), should.BeEmpty)
 }
 
 /*////////////////////////////////////////////////////////////////////////*/

--- a/international-postal-code-api/client_test.go
+++ b/international-postal-code-api/client_test.go
@@ -12,6 +12,8 @@ import (
 	sdk "github.com/smartystreets/smartystreets-go-sdk"
 )
 
+type testContextKey string
+
 func TestClientFixture(t *testing.T) {
 	gunit.Run(new(ClientFixture), t)
 }
@@ -40,7 +42,7 @@ func (f *ClientFixture) TestLookupSerializedAndSent__ResponseSuggestionsIncorpor
 	]`
 	f.input.AdministrativeArea = "42"
 
-	ctx := context.WithValue(context.Background(), "key", "value")
+	ctx := context.WithValue(context.Background(), testContextKey("key"), "value")
 	err := f.client.SendLookupWithContext(ctx, f.input)
 
 	f.So(err, should.BeNil)
@@ -125,7 +127,7 @@ func (f *ClientFixture) TestFullJSONResponseDeserialization() {
 func (f *ClientFixture) TestSendLookupWithContextAndAuth_CredentialSignsRequest() {
 	f.sender.response = `[{"input_id": "1"}]`
 	f.input.Locality = "HI"
-	ctx := context.WithValue(context.Background(), "key", "value")
+	ctx := context.WithValue(context.Background(), testContextKey("key"), "value")
 
 	err := f.client.SendLookupWithContextAndAuth(ctx, f.input, sdk.NewSecretKeyCredential("myAuthID", "myAuthToken"))
 

--- a/international-postal-code-api/client_test.go
+++ b/international-postal-code-api/client_test.go
@@ -151,7 +151,26 @@ func (f *ClientFixture) TestSendLookupWithContextAndAuth_NilCredentialDoesNotSig
 	f.So(f.sender.request.URL.Query().Get("auth-token"), should.BeEmpty)
 }
 
+func (f *ClientFixture) TestSendLookupWithContextAndAuth_SignErrorPropagated() {
+	f.sender.response = `[{"input_id": "1"}]`
+	f.input.Locality = "HI"
+
+	err := f.client.SendLookupWithContextAndAuth(context.Background(), f.input, &FakeCredential{err: errors.New("sign failed")})
+
+	f.So(err, should.NotBeNil)
+	f.So(err.Error(), should.Equal, "sign failed")
+	f.So(f.sender.request, should.BeNil)
+}
+
 /*////////////////////////////////////////////////////////////////////////*/
+
+type FakeCredential struct {
+	err error
+}
+
+func (f *FakeCredential) Sign(*http.Request) error {
+	return f.err
+}
 
 type FakeSender struct {
 	callCount int

--- a/international-postal-code-api/client_test.go
+++ b/international-postal-code-api/client_test.go
@@ -155,7 +155,7 @@ func (f *ClientFixture) TestSendLookupWithContextAndAuth_SignErrorPropagated() {
 	f.sender.response = `[{"input_id": "1"}]`
 	f.input.Locality = "HI"
 
-	err := f.client.SendLookupWithContextAndAuth(context.Background(), f.input, &FakeCredential{err: errors.New("sign failed")})
+	err := f.client.SendLookupWithContextAndAuth(context.Background(), f.input, &sdk.FakeCredential{Err: errors.New("sign failed")})
 
 	f.So(err, should.NotBeNil)
 	f.So(err.Error(), should.Equal, "sign failed")
@@ -163,14 +163,6 @@ func (f *ClientFixture) TestSendLookupWithContextAndAuth_SignErrorPropagated() {
 }
 
 /*////////////////////////////////////////////////////////////////////////*/
-
-type FakeCredential struct {
-	err error
-}
-
-func (f *FakeCredential) Sign(*http.Request) error {
-	return f.err
-}
 
 type FakeSender struct {
 	callCount int

--- a/international-street-api/client.go
+++ b/international-street-api/client.go
@@ -39,7 +39,9 @@ func (c *Client) SendLookupWithContextAndAuth(ctx context.Context, lookup *Looku
 	request := buildRequest(lookup)
 	request = request.WithContext(ctx)
 	if credential != nil {
-		credential.Sign(request)
+		if err := credential.Sign(request); err != nil {
+			return err
+		}
 	}
 	response, err := c.sender.Send(request)
 	if err != nil {

--- a/international-street-api/client.go
+++ b/international-street-api/client.go
@@ -25,21 +25,21 @@ func (c *Client) SendLookup(lookup *Lookup) error {
 }
 
 func (c *Client) SendLookupWithContext(ctx context.Context, lookup *Lookup) error {
-	return c.SendLookupWithContextAndAuth(ctx, lookup, "", "")
+	return c.SendLookupWithContextAndAuth(ctx, lookup, nil)
 }
 
 // SendLookupWithContextAndAuth sends a lookup with the provided context and per-request credentials.
-// If authID and authToken are both non-empty, they will be used for this request instead of the client-level credentials.
+// If credential is non-nil, it will be used to sign this request instead of the client-level credentials.
 // This is useful for multi-tenant scenarios where different requests require different credentials.
-func (c *Client) SendLookupWithContextAndAuth(ctx context.Context, lookup *Lookup, authID, authToken string) error {
+func (c *Client) SendLookupWithContextAndAuth(ctx context.Context, lookup *Lookup, credential sdk.Credential) error {
 	if err := ensureEnoughInfo(lookup); err != nil {
 		return err
 	}
 
 	request := buildRequest(lookup)
 	request = request.WithContext(ctx)
-	if len(authID) > 0 && len(authToken) > 0 {
-		request.SetBasicAuth(authID, authToken)
+	if credential != nil {
+		credential.Sign(request)
 	}
 	response, err := c.sender.Send(request)
 	if err != nil {

--- a/international-street-api/client_test.go
+++ b/international-street-api/client_test.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/smarty/assertions/should"
 	"github.com/smarty/gunit"
+
+	sdk "github.com/smartystreets/smartystreets-go-sdk"
 )
 
 func TestClientFixture(t *testing.T) {
@@ -379,6 +381,35 @@ func (f *ClientFixture) TestFullJSONResponseDeserialization() {
 	f.So(ccomponents.DeliveryInstallationQualifierName, should.Equal, "blank")
 	f.So(ccomponents.RouteType, should.Equal, "blank")
 	f.So(ccomponents.RouteNumber, should.Equal, "blank")
+}
+
+func (f *ClientFixture) TestSendLookupWithContextAndAuth_CredentialSignsRequest() {
+	f.sender.response = `[{"address1": "1"}]`
+	f.input.Freeform = "42"
+	f.input.Country = "CA"
+	ctx := context.WithValue(context.Background(), "key", "value")
+
+	err := f.client.SendLookupWithContextAndAuth(ctx, f.input, sdk.NewSecretKeyCredential("myAuthID", "myAuthToken"))
+
+	f.So(err, should.BeNil)
+	f.So(f.sender.request, should.NotBeNil)
+	f.So(f.sender.request.Context(), should.Equal, ctx)
+	f.So(f.sender.request.URL.Query().Get("auth-id"), should.Equal, "myAuthID")
+	f.So(f.sender.request.URL.Query().Get("auth-token"), should.Equal, "myAuthToken")
+}
+
+func (f *ClientFixture) TestSendLookupWithContextAndAuth_NilCredentialDoesNotSign() {
+	f.sender.response = `[{"address1": "1"}]`
+	f.input.Freeform = "42"
+	f.input.Country = "CA"
+	ctx := context.Background()
+
+	err := f.client.SendLookupWithContextAndAuth(ctx, f.input, nil)
+
+	f.So(err, should.BeNil)
+	f.So(f.sender.request, should.NotBeNil)
+	f.So(f.sender.request.URL.Query().Get("auth-id"), should.BeEmpty)
+	f.So(f.sender.request.URL.Query().Get("auth-token"), should.BeEmpty)
 }
 
 /*////////////////////////////////////////////////////////////////////////*/

--- a/international-street-api/client_test.go
+++ b/international-street-api/client_test.go
@@ -414,7 +414,27 @@ func (f *ClientFixture) TestSendLookupWithContextAndAuth_NilCredentialDoesNotSig
 	f.So(f.sender.request.URL.Query().Get("auth-token"), should.BeEmpty)
 }
 
+func (f *ClientFixture) TestSendLookupWithContextAndAuth_SignErrorPropagated() {
+	f.sender.response = `[{"address1": "1"}]`
+	f.input.Freeform = "42"
+	f.input.Country = "CA"
+
+	err := f.client.SendLookupWithContextAndAuth(context.Background(), f.input, &FakeCredential{err: errors.New("sign failed")})
+
+	f.So(err, should.NotBeNil)
+	f.So(err.Error(), should.Equal, "sign failed")
+	f.So(f.sender.request, should.BeNil)
+}
+
 /*////////////////////////////////////////////////////////////////////////*/
+
+type FakeCredential struct {
+	err error
+}
+
+func (f *FakeCredential) Sign(*http.Request) error {
+	return f.err
+}
 
 type FakeSender struct {
 	callCount int

--- a/international-street-api/client_test.go
+++ b/international-street-api/client_test.go
@@ -419,7 +419,7 @@ func (f *ClientFixture) TestSendLookupWithContextAndAuth_SignErrorPropagated() {
 	f.input.Freeform = "42"
 	f.input.Country = "CA"
 
-	err := f.client.SendLookupWithContextAndAuth(context.Background(), f.input, &FakeCredential{err: errors.New("sign failed")})
+	err := f.client.SendLookupWithContextAndAuth(context.Background(), f.input, &sdk.FakeCredential{Err: errors.New("sign failed")})
 
 	f.So(err, should.NotBeNil)
 	f.So(err.Error(), should.Equal, "sign failed")
@@ -427,14 +427,6 @@ func (f *ClientFixture) TestSendLookupWithContextAndAuth_SignErrorPropagated() {
 }
 
 /*////////////////////////////////////////////////////////////////////////*/
-
-type FakeCredential struct {
-	err error
-}
-
-func (f *FakeCredential) Sign(*http.Request) error {
-	return f.err
-}
 
 type FakeSender struct {
 	callCount int

--- a/international-street-api/client_test.go
+++ b/international-street-api/client_test.go
@@ -12,6 +12,8 @@ import (
 	sdk "github.com/smartystreets/smartystreets-go-sdk"
 )
 
+type testContextKey string
+
 func TestClientFixture(t *testing.T) {
 	gunit.Run(new(ClientFixture), t)
 }
@@ -40,7 +42,7 @@ func (f *ClientFixture) TestAddressLookupSerializedAndSent__ResponseSuggestionsI
 	f.input.Freeform = "42"
 	f.input.Country = "CA"
 
-	ctx := context.WithValue(context.Background(), "key", "value")
+	ctx := context.WithValue(context.Background(), testContextKey("key"), "value")
 	err := f.client.SendLookupWithContext(ctx, f.input)
 
 	f.So(err, should.BeNil)
@@ -387,7 +389,7 @@ func (f *ClientFixture) TestSendLookupWithContextAndAuth_CredentialSignsRequest(
 	f.sender.response = `[{"address1": "1"}]`
 	f.input.Freeform = "42"
 	f.input.Country = "CA"
-	ctx := context.WithValue(context.Background(), "key", "value")
+	ctx := context.WithValue(context.Background(), testContextKey("key"), "value")
 
 	err := f.client.SendLookupWithContextAndAuth(ctx, f.input, sdk.NewSecretKeyCredential("myAuthID", "myAuthToken"))
 

--- a/secret_key_credential.go
+++ b/secret_key_credential.go
@@ -11,7 +11,7 @@ type secretKeyCredential struct {
 	authToken string
 }
 
-func NewSecretKeyCredential(authID, authToken string) *secretKeyCredential {
+func NewSecretKeyCredential(authID, authToken string) Credential {
 	if oldStyleBase64AuthTokenIsAlreadyURLEncoded(authToken) {
 		authToken, _ = url.QueryUnescape(authToken)
 	}

--- a/us-enrichment-api/client.go
+++ b/us-enrichment-api/client.go
@@ -28,11 +28,11 @@ func (c *Client) SendPropertyPrincipal(lookup *Lookup) (error, []*PrincipalRespo
 }
 
 // SendPropertyPrincipalWithContextAndAuth sends a lookup with the provided context and per-request credentials.
-// If authID and authToken are both non-empty, they will be used for this request instead of the client-level credentials.
+// If credential is non-nil, it will be used to sign this request instead of the client-level credentials.
 // This is useful for multi-tenant scenarios where different requests require different credentials.
-func (c *Client) SendPropertyPrincipalWithContextAndAuth(ctx context.Context, lookup *Lookup, authID, authToken string) (error, []*PrincipalResponse) {
+func (c *Client) SendPropertyPrincipalWithContextAndAuth(ctx context.Context, lookup *Lookup, credential sdk.Credential) (error, []*PrincipalResponse) {
 	propertyLookup := &principalLookup{Lookup: lookup}
-	err := c.sendLookupWithContextAndAuth(ctx, propertyLookup, authID, authToken)
+	err := c.sendLookupWithContextAndAuth(ctx, propertyLookup, credential)
 	return err, propertyLookup.Response
 }
 
@@ -43,11 +43,11 @@ func (c *Client) SendGeoReference(lookup *Lookup) (error, []*GeoReferenceRespons
 }
 
 // SendGeoReferenceWithContextAndAuth sends a lookup with the provided context and per-request credentials.
-// If authID and authToken are both non-empty, they will be used for this request instead of the client-level credentials.
+// If credential is non-nil, it will be used to sign this request instead of the client-level credentials.
 // This is useful for multi-tenant scenarios where different requests require different credentials.
-func (c *Client) SendGeoReferenceWithContextAndAuth(ctx context.Context, lookup *Lookup, authID, authToken string) (error, []*GeoReferenceResponse) {
+func (c *Client) SendGeoReferenceWithContextAndAuth(ctx context.Context, lookup *Lookup, credential sdk.Credential) (error, []*GeoReferenceResponse) {
 	geoRefLookup := &geoReferenceLookup{Lookup: lookup}
-	err := c.sendLookupWithContextAndAuth(ctx, geoRefLookup, authID, authToken)
+	err := c.sendLookupWithContextAndAuth(ctx, geoRefLookup, credential)
 	return err, geoRefLookup.Response
 }
 
@@ -58,11 +58,11 @@ func (c *Client) SendGeoReferenceWithVersion(lookup *Lookup, censusVersion strin
 }
 
 // SendGeoReferenceWithVersionContextAndAuth sends a lookup with the provided context and per-request credentials.
-// If authID and authToken are both non-empty, they will be used for this request instead of the client-level credentials.
+// If credential is non-nil, it will be used to sign this request instead of the client-level credentials.
 // This is useful for multi-tenant scenarios where different requests require different credentials.
-func (c *Client) SendGeoReferenceWithVersionContextAndAuth(ctx context.Context, lookup *Lookup, censusVersion, authID, authToken string) (error, []*GeoReferenceResponse) {
+func (c *Client) SendGeoReferenceWithVersionContextAndAuth(ctx context.Context, lookup *Lookup, censusVersion string, credential sdk.Credential) (error, []*GeoReferenceResponse) {
 	geoRefLookup := &geoReferenceLookup{Lookup: lookup, CensusVersion: censusVersion}
-	err := c.sendLookupWithContextAndAuth(ctx, geoRefLookup, authID, authToken)
+	err := c.sendLookupWithContextAndAuth(ctx, geoRefLookup, credential)
 	return err, geoRefLookup.Response
 }
 
@@ -73,11 +73,11 @@ func (c *Client) SendRisk(lookup *Lookup) (error, []*RiskResponse) {
 }
 
 // SendRiskWithContextAndAuth sends a lookup with the provided context and per-request credentials.
-// If authID and authToken are both non-empty, they will be used for this request instead of the client-level credentials.
+// If credential is non-nil, it will be used to sign this request instead of the client-level credentials.
 // This is useful for multi-tenant scenarios where different requests require different credentials.
-func (c *Client) SendRiskWithContextAndAuth(ctx context.Context, lookup *Lookup, authID, authToken string) (error, []*RiskResponse) {
+func (c *Client) SendRiskWithContextAndAuth(ctx context.Context, lookup *Lookup, credential sdk.Credential) (error, []*RiskResponse) {
 	rLookup := &riskLookup{Lookup: lookup}
-	err := c.sendLookupWithContextAndAuth(ctx, rLookup, authID, authToken)
+	err := c.sendLookupWithContextAndAuth(ctx, rLookup, credential)
 	return err, rLookup.Response
 }
 
@@ -88,11 +88,11 @@ func (c *Client) SendSecondary(lookup *Lookup) (error, []*SecondaryResponse) {
 }
 
 // SendSecondaryWithContextAndAuth sends a lookup with the provided context and per-request credentials.
-// If authID and authToken are both non-empty, they will be used for this request instead of the client-level credentials.
+// If credential is non-nil, it will be used to sign this request instead of the client-level credentials.
 // This is useful for multi-tenant scenarios where different requests require different credentials.
-func (c *Client) SendSecondaryWithContextAndAuth(ctx context.Context, lookup *Lookup, authID, authToken string) (error, []*SecondaryResponse) {
+func (c *Client) SendSecondaryWithContextAndAuth(ctx context.Context, lookup *Lookup, credential sdk.Credential) (error, []*SecondaryResponse) {
 	sLookup := &secondaryLookup{Lookup: lookup}
-	err := c.sendLookupWithContextAndAuth(ctx, sLookup, authID, authToken)
+	err := c.sendLookupWithContextAndAuth(ctx, sLookup, credential)
 	return err, sLookup.Response
 }
 
@@ -108,11 +108,11 @@ func (c *Client) SendSecondaryCount(lookup *Lookup) (error, []*SecondaryCountRes
 }
 
 // SendSecondaryCountWithContextAndAuth sends a lookup with the provided context and per-request credentials.
-// If authID and authToken are both non-empty, they will be used for this request instead of the client-level credentials.
+// If credential is non-nil, it will be used to sign this request instead of the client-level credentials.
 // This is useful for multi-tenant scenarios where different requests require different credentials.
-func (c *Client) SendSecondaryCountWithContextAndAuth(ctx context.Context, lookup *Lookup, authID, authToken string) (error, []*SecondaryCountResponse) {
+func (c *Client) SendSecondaryCountWithContextAndAuth(ctx context.Context, lookup *Lookup, credential sdk.Credential) (error, []*SecondaryCountResponse) {
 	scLookup := &secondaryCountLookup{Lookup: lookup}
-	err := c.sendLookupWithContextAndAuth(ctx, scLookup, authID, authToken)
+	err := c.sendLookupWithContextAndAuth(ctx, scLookup, credential)
 	return err, scLookup.Response
 }
 
@@ -127,43 +127,43 @@ func (c *Client) SendUniversalLookup(lookup *Lookup, dataSet, dataSubset string)
 
 // SendUniversalLookupWithContext sends a lookup with the provided context.
 func (c *Client) SendUniversalLookupWithContext(ctx context.Context, lookup *Lookup, dataSet, dataSubset string) (error, []byte) {
-	return c.SendUniversalLookupWithContextAndAuth(ctx, lookup, dataSet, dataSubset, "", "")
+	return c.SendUniversalLookupWithContextAndAuth(ctx, lookup, dataSet, dataSubset, nil)
 }
 
 // SendUniversalLookupWithContextAndAuth sends a lookup with the provided context and per-request credentials.
-// If authID and authToken are both non-empty, they will be used for this request instead of the client-level credentials.
+// If credential is non-nil, it will be used to sign this request instead of the client-level credentials.
 // This is useful for multi-tenant scenarios where different requests require different credentials.
-func (c *Client) SendUniversalLookupWithContextAndAuth(ctx context.Context, lookup *Lookup, dataSet, dataSubset, authID, authToken string) (error, []byte) {
+func (c *Client) SendUniversalLookupWithContextAndAuth(ctx context.Context, lookup *Lookup, dataSet, dataSubset string, credential sdk.Credential) (error, []byte) {
 	u := &universalLookup{
 		Lookup:     lookup,
 		DataSet:    dataSet,
 		DataSubset: dataSubset,
 	}
 
-	err := c.sendLookupWithContextAndAuth(ctx, u, authID, authToken)
+	err := c.sendLookupWithContextAndAuth(ctx, u, credential)
 	return err, u.Response
 }
 
 func (c *Client) sendLookup(lookup enrichmentLookup) error {
-	return c.sendLookupWithContextAndAuth(context.Background(), lookup, "", "")
+	return c.sendLookupWithContextAndAuth(context.Background(), lookup, nil)
 }
 
 func (c *Client) sendLookupWithContext(ctx context.Context, lookup enrichmentLookup) error {
-	return c.sendLookupWithContextAndAuth(ctx, lookup, "", "")
+	return c.sendLookupWithContextAndAuth(ctx, lookup, nil)
 }
 
 // sendLookupWithContextAndAuth sends an enrichmentLookup with the provided context and per-request credentials.
-// If authID and authToken are both non-empty, they will be used for this request instead of the client-level credentials.
+// If credential is non-nil, it will be used to sign this request instead of the client-level credentials.
 // This is useful for multi-tenant scenarios where different requests require different credentials.
-func (c *Client) sendLookupWithContextAndAuth(ctx context.Context, lookup enrichmentLookup, authID, authToken string) error {
+func (c *Client) sendLookupWithContextAndAuth(ctx context.Context, lookup enrichmentLookup, credential sdk.Credential) error {
 	if lookup == nil || lookup.getLookup() == nil {
 		return nil
 	}
 
 	request := buildRequest(lookup)
 	request = request.WithContext(ctx)
-	if len(authID) > 0 && len(authToken) > 0 {
-		request.SetBasicAuth(authID, authToken)
+	if credential != nil {
+		credential.Sign(request)
 	}
 	response, err := c.sender.Send(request)
 	if err != nil {

--- a/us-enrichment-api/client.go
+++ b/us-enrichment-api/client.go
@@ -163,7 +163,9 @@ func (c *Client) sendLookupWithContextAndAuth(ctx context.Context, lookup enrich
 	request := buildRequest(lookup)
 	request = request.WithContext(ctx)
 	if credential != nil {
-		credential.Sign(request)
+		if err := credential.Sign(request); err != nil {
+			return err
+		}
 	}
 	response, err := c.sender.Send(request)
 	if err != nil {

--- a/us-enrichment-api/client_test.go
+++ b/us-enrichment-api/client_test.go
@@ -231,7 +231,7 @@ func (f *ClientFixture) TestSendPropertyPrincipalWithContextAndAuth() {
 	lookup := &Lookup{SmartyKey: "123"}
 	ctx := context.WithValue(context.Background(), "key", "value")
 
-	err, response := f.client.SendPropertyPrincipalWithContextAndAuth(ctx, lookup, "myAuthID", "myAuthToken")
+	err, response := f.client.SendPropertyPrincipalWithContextAndAuth(ctx, lookup, sdk.NewBasicAuthCredential("myAuthID", "myAuthToken"))
 
 	f.So(err, should.BeNil)
 	f.So(f.sender.request, should.NotBeNil)
@@ -259,7 +259,7 @@ func (f *ClientFixture) TestSendGeoReferenceWithContextAndAuth() {
 	lookup := &Lookup{SmartyKey: "123"}
 	ctx := context.WithValue(context.Background(), "key", "value")
 
-	err, response := f.client.SendGeoReferenceWithContextAndAuth(ctx, lookup, "authID", "authToken")
+	err, response := f.client.SendGeoReferenceWithContextAndAuth(ctx, lookup, sdk.NewBasicAuthCredential("authID", "authToken"))
 
 	f.So(err, should.BeNil)
 	f.So(f.sender.request.Context(), should.Equal, ctx)
@@ -286,7 +286,7 @@ func (f *ClientFixture) TestSendGeoReferenceWithVersionContextAndAuth() {
 	lookup := &Lookup{SmartyKey: "123"}
 	ctx := context.WithValue(context.Background(), "key", "value")
 
-	err, response := f.client.SendGeoReferenceWithVersionContextAndAuth(ctx, lookup, "census-2010", "authID", "authToken")
+	err, response := f.client.SendGeoReferenceWithVersionContextAndAuth(ctx, lookup, "census-2010", sdk.NewBasicAuthCredential("authID", "authToken"))
 
 	f.So(err, should.BeNil)
 	f.So(f.sender.request.URL.Path, should.Equal, "/lookup/123/geo-reference/census-2010")
@@ -314,7 +314,7 @@ func (f *ClientFixture) TestSendRiskWithContextAndAuth() {
 	lookup := &Lookup{SmartyKey: "123"}
 	ctx := context.WithValue(context.Background(), "key", "value")
 
-	err, response := f.client.SendRiskWithContextAndAuth(ctx, lookup, "authID", "authToken")
+	err, response := f.client.SendRiskWithContextAndAuth(ctx, lookup, sdk.NewBasicAuthCredential("authID", "authToken"))
 
 	f.So(err, should.BeNil)
 	f.So(f.sender.request.Context(), should.Equal, ctx)
@@ -341,7 +341,7 @@ func (f *ClientFixture) TestSendSecondaryWithContextAndAuth() {
 	lookup := &Lookup{SmartyKey: "123"}
 	ctx := context.WithValue(context.Background(), "key", "value")
 
-	err, response := f.client.SendSecondaryWithContextAndAuth(ctx, lookup, "authID", "authToken")
+	err, response := f.client.SendSecondaryWithContextAndAuth(ctx, lookup, sdk.NewBasicAuthCredential("authID", "authToken"))
 
 	f.So(err, should.BeNil)
 	f.So(f.sender.request.Context(), should.Equal, ctx)
@@ -369,7 +369,7 @@ func (f *ClientFixture) TestSendSecondaryCountWithContextAndAuth() {
 	lookup := &Lookup{SmartyKey: "123"}
 	ctx := context.WithValue(context.Background(), "key", "value")
 
-	err, response := f.client.SendSecondaryCountWithContextAndAuth(ctx, lookup, "authID", "authToken")
+	err, response := f.client.SendSecondaryCountWithContextAndAuth(ctx, lookup, sdk.NewBasicAuthCredential("authID", "authToken"))
 
 	f.So(err, should.BeNil)
 	f.So(f.sender.request.Context(), should.Equal, ctx)
@@ -413,7 +413,7 @@ func (f *ClientFixture) TestSendUniversalLookupWithContextAndAuth() {
 	lookup := &Lookup{SmartyKey: "123"}
 	ctx := context.WithValue(context.Background(), "key", "value")
 
-	err, response := f.client.SendUniversalLookupWithContextAndAuth(ctx, lookup, "property", "principal", "authID", "authToken")
+	err, response := f.client.SendUniversalLookupWithContextAndAuth(ctx, lookup, "property", "principal", sdk.NewBasicAuthCredential("authID", "authToken"))
 
 	f.So(err, should.BeNil)
 	f.So(f.sender.request.URL.Path, should.Equal, "/lookup/123/property/principal")
@@ -536,30 +536,26 @@ func (f *ClientFixture) TestIsHTTPErrorCode_NilError() {
 
 // Tests for per-request auth with empty credentials (should not set auth)
 
-func (f *ClientFixture) TestPerRequestAuthEmptyCredentialsNotSet() {
+func (f *ClientFixture) TestPerRequestAuthNilCredentialNotSet() {
 	f.sender.response = validPrincipalResponse
 	lookup := &Lookup{SmartyKey: "123"}
 	ctx := context.Background()
 
-	f.client.SendPropertyPrincipalWithContextAndAuth(ctx, lookup, "", "")
+	f.client.SendPropertyPrincipalWithContextAndAuth(ctx, lookup, nil)
 
 	f.So(f.sender.hasBasicAuth, should.BeFalse)
 }
 
-func (f *ClientFixture) TestPerRequestAuthPartialCredentialsNotSet() {
+func (f *ClientFixture) TestPerRequestAuthWithSecretKeyCredential() {
 	f.sender.response = validPrincipalResponse
 	lookup := &Lookup{SmartyKey: "123"}
 	ctx := context.Background()
 
-	// Only authID provided
-	f.client.SendPropertyPrincipalWithContextAndAuth(ctx, lookup, "authID", "")
-	f.So(f.sender.hasBasicAuth, should.BeFalse)
+	f.client.SendPropertyPrincipalWithContextAndAuth(ctx, lookup, sdk.NewSecretKeyCredential("myAuthID", "myAuthToken"))
 
-	f.sender.Reset()
-
-	// Only authToken provided
-	f.client.SendPropertyPrincipalWithContextAndAuth(ctx, lookup, "", "authToken")
 	f.So(f.sender.hasBasicAuth, should.BeFalse)
+	f.So(f.sender.request.URL.Query().Get("auth-id"), should.Equal, "myAuthID")
+	f.So(f.sender.request.URL.Query().Get("auth-token"), should.Equal, "myAuthToken")
 }
 
 // Tests for deprecated methods

--- a/us-enrichment-api/client_test.go
+++ b/us-enrichment-api/client_test.go
@@ -604,7 +604,7 @@ func (f *ClientFixture) TestSendPropertyPrincipalWithContextAndAuth_SignErrorPro
 	f.sender.response = validPrincipalResponse
 	lookup := &Lookup{SmartyKey: "123"}
 
-	err, _ := f.client.SendPropertyPrincipalWithContextAndAuth(context.Background(), lookup, &FakeCredential{err: errors.New("sign failed")})
+	err, _ := f.client.SendPropertyPrincipalWithContextAndAuth(context.Background(), lookup, &sdk.FakeCredential{Err: errors.New("sign failed")})
 
 	f.So(err, should.NotBeNil)
 	f.So(err.Error(), should.Equal, "sign failed")
@@ -612,14 +612,6 @@ func (f *ClientFixture) TestSendPropertyPrincipalWithContextAndAuth_SignErrorPro
 }
 
 /**************************************************************************/
-
-type FakeCredential struct {
-	err error
-}
-
-func (f *FakeCredential) Sign(*http.Request) error {
-	return f.err
-}
 
 type FakeSender struct {
 	callCount int

--- a/us-enrichment-api/client_test.go
+++ b/us-enrichment-api/client_test.go
@@ -600,7 +600,26 @@ var validRiskResponse = `[{"smarty_key":"123","data_set_name":"risk","attributes
 var validSecondaryResponse = `[{"smarty_key":"123","root_address":{"secondary_count":10,"smarty_key":"123","primary_number":"3105","street_name":"National Park Service","street_suffix":"Rd","city_name":"Juneau","state_abbreviation":"AK","zipcode":"99801","plus4_code":"8437"},"aliases":[{"smarty_key":"1882749021","primary_number":"3105","street_name":"National Park","street_suffix":"Rd","city_name":"Juneau","state_abbreviation":"AK","zipcode":"99801","plus4_code":"8437"}],"secondaries":[{"smarty_key":"1785903890","secondary_designator":"Apt","secondary_number":"A5","plus4_code":"8437"},{"smarty_key":"696702050","secondary_designator":"Apt","secondary_number":"B1","plus4_code":"8441"}]}]`
 var validSecondaryCountResponse = `[{"smarty_key":"123","count":3}]`
 
+func (f *ClientFixture) TestSendPropertyPrincipalWithContextAndAuth_SignErrorPropagated() {
+	f.sender.response = validPrincipalResponse
+	lookup := &Lookup{SmartyKey: "123"}
+
+	err, _ := f.client.SendPropertyPrincipalWithContextAndAuth(context.Background(), lookup, &FakeCredential{err: errors.New("sign failed")})
+
+	f.So(err, should.NotBeNil)
+	f.So(err.Error(), should.Equal, "sign failed")
+	f.So(f.sender.request, should.BeNil)
+}
+
 /**************************************************************************/
+
+type FakeCredential struct {
+	err error
+}
+
+func (f *FakeCredential) Sign(*http.Request) error {
+	return f.err
+}
 
 type FakeSender struct {
 	callCount int

--- a/us-enrichment-api/client_test.go
+++ b/us-enrichment-api/client_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/smartystreets/smartystreets-go-sdk"
 )
 
+type testContextKey string
+
 func TestClientFixture(t *testing.T) {
 	gunit.Run(new(ClientFixture), t)
 }
@@ -36,7 +38,7 @@ func (f *ClientFixture) TestLookupSerializedAndSentWithContext__ResponseSuggesti
 	f.sender.response = validPrincipalResponse
 	f.input = &principalLookup{Lookup: &Lookup{SmartyKey: smartyKey}}
 
-	ctx := context.WithValue(context.Background(), "key", "value")
+	ctx := context.WithValue(context.Background(), testContextKey("key"), "value")
 	err := f.client.sendLookupWithContext(ctx, f.input)
 
 	f.So(err, should.BeNil)
@@ -125,7 +127,7 @@ func (f *ClientFixture) TestGeoReference() {
 	f.sender.response = validGeoReferenceResponse
 	f.input = &geoReferenceLookup{Lookup: &Lookup{SmartyKey: smartyKey}}
 
-	ctx := context.WithValue(context.Background(), "key", "value")
+	ctx := context.WithValue(context.Background(), testContextKey("key"), "value")
 	err := f.client.sendLookupWithContext(ctx, f.input)
 
 	f.So(err, should.BeNil)
@@ -147,7 +149,7 @@ func (f *ClientFixture) TestRiskLookup() {
 	f.sender.response = validRiskResponse
 	f.input = &riskLookup{Lookup: &Lookup{SmartyKey: smartyKey}}
 
-	ctx := context.WithValue(context.Background(), "key", "value")
+	ctx := context.WithValue(context.Background(), testContextKey("key"), "value")
 	err := f.client.sendLookupWithContext(ctx, f.input)
 
 	f.So(err, should.BeNil)
@@ -169,7 +171,7 @@ func (f *ClientFixture) TestSecondaryLookup() {
 	f.sender.response = validSecondaryResponse
 	f.input = &secondaryLookup{Lookup: &Lookup{SmartyKey: smartyKey}}
 
-	ctx := context.WithValue(context.Background(), "key", "value")
+	ctx := context.WithValue(context.Background(), testContextKey("key"), "value")
 	err := f.client.sendLookupWithContext(ctx, f.input)
 
 	f.So(err, should.BeNil)
@@ -191,7 +193,7 @@ func (f *ClientFixture) TestSecondaryCount() {
 	f.sender.response = validSecondaryCountResponse
 	f.input = &secondaryCountLookup{Lookup: &Lookup{SmartyKey: smartyKey}}
 
-	ctx := context.WithValue(context.Background(), "key", "value")
+	ctx := context.WithValue(context.Background(), testContextKey("key"), "value")
 	err := f.client.sendLookupWithContext(ctx, f.input)
 
 	f.So(err, should.BeNil)
@@ -229,7 +231,7 @@ func (f *ClientFixture) TestSendPropertyPrincipal() {
 func (f *ClientFixture) TestSendPropertyPrincipalWithContextAndAuth() {
 	f.sender.response = validPrincipalResponse
 	lookup := &Lookup{SmartyKey: "123"}
-	ctx := context.WithValue(context.Background(), "key", "value")
+	ctx := context.WithValue(context.Background(), testContextKey("key"), "value")
 
 	err, response := f.client.SendPropertyPrincipalWithContextAndAuth(ctx, lookup, sdk.NewBasicAuthCredential("myAuthID", "myAuthToken"))
 
@@ -257,7 +259,7 @@ func (f *ClientFixture) TestSendGeoReferencePublicMethod() {
 func (f *ClientFixture) TestSendGeoReferenceWithContextAndAuth() {
 	f.sender.response = validGeoReferenceResponse
 	lookup := &Lookup{SmartyKey: "123"}
-	ctx := context.WithValue(context.Background(), "key", "value")
+	ctx := context.WithValue(context.Background(), testContextKey("key"), "value")
 
 	err, response := f.client.SendGeoReferenceWithContextAndAuth(ctx, lookup, sdk.NewBasicAuthCredential("authID", "authToken"))
 
@@ -284,7 +286,7 @@ func (f *ClientFixture) TestSendGeoReferenceWithVersion() {
 func (f *ClientFixture) TestSendGeoReferenceWithVersionContextAndAuth() {
 	f.sender.response = validGeoReferenceResponse
 	lookup := &Lookup{SmartyKey: "123"}
-	ctx := context.WithValue(context.Background(), "key", "value")
+	ctx := context.WithValue(context.Background(), testContextKey("key"), "value")
 
 	err, response := f.client.SendGeoReferenceWithVersionContextAndAuth(ctx, lookup, "census-2010", sdk.NewBasicAuthCredential("authID", "authToken"))
 
@@ -312,7 +314,7 @@ func (f *ClientFixture) TestSendRiskPublicMethod() {
 func (f *ClientFixture) TestSendRiskWithContextAndAuth() {
 	f.sender.response = validRiskResponse
 	lookup := &Lookup{SmartyKey: "123"}
-	ctx := context.WithValue(context.Background(), "key", "value")
+	ctx := context.WithValue(context.Background(), testContextKey("key"), "value")
 
 	err, response := f.client.SendRiskWithContextAndAuth(ctx, lookup, sdk.NewBasicAuthCredential("authID", "authToken"))
 
@@ -339,7 +341,7 @@ func (f *ClientFixture) TestSendSecondaryPublicMethod() {
 func (f *ClientFixture) TestSendSecondaryWithContextAndAuth() {
 	f.sender.response = validSecondaryResponse
 	lookup := &Lookup{SmartyKey: "123"}
-	ctx := context.WithValue(context.Background(), "key", "value")
+	ctx := context.WithValue(context.Background(), testContextKey("key"), "value")
 
 	err, response := f.client.SendSecondaryWithContextAndAuth(ctx, lookup, sdk.NewBasicAuthCredential("authID", "authToken"))
 
@@ -367,7 +369,7 @@ func (f *ClientFixture) TestSendSecondaryCountPublicMethod() {
 func (f *ClientFixture) TestSendSecondaryCountWithContextAndAuth() {
 	f.sender.response = validSecondaryCountResponse
 	lookup := &Lookup{SmartyKey: "123"}
-	ctx := context.WithValue(context.Background(), "key", "value")
+	ctx := context.WithValue(context.Background(), testContextKey("key"), "value")
 
 	err, response := f.client.SendSecondaryCountWithContextAndAuth(ctx, lookup, sdk.NewBasicAuthCredential("authID", "authToken"))
 
@@ -396,7 +398,7 @@ func (f *ClientFixture) TestSendUniversalLookup() {
 func (f *ClientFixture) TestSendUniversalLookupWithContext() {
 	f.sender.response = validPrincipalResponse
 	lookup := &Lookup{SmartyKey: "123"}
-	ctx := context.WithValue(context.Background(), "key", "value")
+	ctx := context.WithValue(context.Background(), testContextKey("key"), "value")
 
 	err, response := f.client.SendUniversalLookupWithContext(ctx, lookup, "property", "principal")
 
@@ -411,7 +413,7 @@ func (f *ClientFixture) TestSendUniversalLookupWithContext() {
 func (f *ClientFixture) TestSendUniversalLookupWithContextAndAuth() {
 	f.sender.response = validPrincipalResponse
 	lookup := &Lookup{SmartyKey: "123"}
-	ctx := context.WithValue(context.Background(), "key", "value")
+	ctx := context.WithValue(context.Background(), testContextKey("key"), "value")
 
 	err, response := f.client.SendUniversalLookupWithContextAndAuth(ctx, lookup, "property", "principal", sdk.NewBasicAuthCredential("authID", "authToken"))
 

--- a/us-extract-api/client.go
+++ b/us-extract-api/client.go
@@ -38,7 +38,9 @@ func (c *Client) SendLookupWithContextAndAuth(ctx context.Context, lookup *Looku
 	request := buildRequest(lookup)
 	request = request.WithContext(ctx)
 	if credential != nil {
-		credential.Sign(request)
+		if err := credential.Sign(request); err != nil {
+			return err
+		}
 	}
 	response, err := c.sender.Send(request)
 	if err != nil {

--- a/us-extract-api/client.go
+++ b/us-extract-api/client.go
@@ -20,25 +20,25 @@ func NewClient(sender sdk.RequestSender) *Client {
 
 // SendBatch sends the batch of inputs, populating the output for each input if the batch was successful.
 func (c *Client) SendLookup(lookup *Lookup) error {
-	return c.SendLookupWithContextAndAuth(context.Background(), lookup, "", "")
+	return c.SendLookupWithContextAndAuth(context.Background(), lookup, nil)
 }
 
 func (c *Client) SendLookupWithContext(ctx context.Context, lookup *Lookup) error {
-	return c.SendLookupWithContextAndAuth(ctx, lookup, "", "")
+	return c.SendLookupWithContextAndAuth(ctx, lookup, nil)
 }
 
 // SendLookupWithContextAndAuth sends a lookup with the provided context and per-request credentials.
-// If authID and authToken are both non-empty, they will be used for this request instead of the client-level credentials.
+// If credential is non-nil, it will be used to sign this request instead of the client-level credentials.
 // This is useful for multi-tenant scenarios where different requests require different credentials.
-func (c *Client) SendLookupWithContextAndAuth(ctx context.Context, lookup *Lookup, authID, authToken string) error {
+func (c *Client) SendLookupWithContextAndAuth(ctx context.Context, lookup *Lookup, credential sdk.Credential) error {
 	if lookup == nil || len(lookup.Text) == 0 {
 		return nil
 	}
 
 	request := buildRequest(lookup)
 	request = request.WithContext(ctx)
-	if len(authID) > 0 && len(authToken) > 0 {
-		request.SetBasicAuth(authID, authToken)
+	if credential != nil {
+		credential.Sign(request)
 	}
 	response, err := c.sender.Send(request)
 	if err != nil {

--- a/us-extract-api/client_test.go
+++ b/us-extract-api/client_test.go
@@ -114,7 +114,7 @@ func (f *ClientFixture) TestSendLookupWithContextAndAuth_SignErrorPropagated() {
 	f.sender.response = `{"meta": {"lines": 42}}`
 	f.input.Text = "42"
 
-	err := f.client.SendLookupWithContextAndAuth(context.Background(), f.input, &FakeCredential{err: errors.New("sign failed")})
+	err := f.client.SendLookupWithContextAndAuth(context.Background(), f.input, &sdk.FakeCredential{Err: errors.New("sign failed")})
 
 	f.So(err, should.NotBeNil)
 	f.So(err.Error(), should.Equal, "sign failed")
@@ -122,14 +122,6 @@ func (f *ClientFixture) TestSendLookupWithContextAndAuth_SignErrorPropagated() {
 }
 
 /*////////////////////////////////////////////////////////////////////////*/
-
-type FakeCredential struct {
-	err error
-}
-
-func (f *FakeCredential) Sign(*http.Request) error {
-	return f.err
-}
 
 type FakeSender struct {
 	callCount int

--- a/us-extract-api/client_test.go
+++ b/us-extract-api/client_test.go
@@ -110,7 +110,26 @@ func (f *ClientFixture) TestSendLookupWithContextAndAuth_NilCredentialDoesNotSig
 	f.So(f.sender.request.URL.Query().Get("auth-token"), should.BeEmpty)
 }
 
+func (f *ClientFixture) TestSendLookupWithContextAndAuth_SignErrorPropagated() {
+	f.sender.response = `{"meta": {"lines": 42}}`
+	f.input.Text = "42"
+
+	err := f.client.SendLookupWithContextAndAuth(context.Background(), f.input, &FakeCredential{err: errors.New("sign failed")})
+
+	f.So(err, should.NotBeNil)
+	f.So(err.Error(), should.Equal, "sign failed")
+	f.So(f.sender.request, should.BeNil)
+}
+
 /*////////////////////////////////////////////////////////////////////////*/
+
+type FakeCredential struct {
+	err error
+}
+
+func (f *FakeCredential) Sign(*http.Request) error {
+	return f.err
+}
 
 type FakeSender struct {
 	callCount int

--- a/us-extract-api/client_test.go
+++ b/us-extract-api/client_test.go
@@ -12,6 +12,8 @@ import (
 	sdk "github.com/smartystreets/smartystreets-go-sdk"
 )
 
+type testContextKey string
+
 func TestClientFixture(t *testing.T) {
 	gunit.Run(new(ClientFixture), t)
 }
@@ -35,7 +37,7 @@ func (f *ClientFixture) TestLookupSerializedAndSentWithContext__ResponseSuggesti
 	f.sender.response = `{"meta": {"lines": 42}}`
 	f.input.Text = "42"
 
-	ctx := context.WithValue(context.Background(), "key", "value")
+	ctx := context.WithValue(context.Background(), testContextKey("key"), "value")
 	err := f.client.SendLookupWithContext(ctx, f.input)
 
 	f.So(err, should.BeNil)
@@ -84,7 +86,7 @@ func (f *ClientFixture) TestDeserializationErrorPreventsDeserialization() {
 func (f *ClientFixture) TestSendLookupWithContextAndAuth_CredentialSignsRequest() {
 	f.sender.response = `{"meta": {"lines": 42}}`
 	f.input.Text = "42"
-	ctx := context.WithValue(context.Background(), "key", "value")
+	ctx := context.WithValue(context.Background(), testContextKey("key"), "value")
 
 	err := f.client.SendLookupWithContextAndAuth(ctx, f.input, sdk.NewSecretKeyCredential("myAuthID", "myAuthToken"))
 

--- a/us-extract-api/client_test.go
+++ b/us-extract-api/client_test.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/smarty/assertions/should"
 	"github.com/smarty/gunit"
+
+	sdk "github.com/smartystreets/smartystreets-go-sdk"
 )
 
 func TestClientFixture(t *testing.T) {
@@ -77,6 +79,33 @@ func (f *ClientFixture) TestDeserializationErrorPreventsDeserialization() {
 
 	f.So(err, should.NotBeNil)
 	f.So(f.input.Result, should.BeNil)
+}
+
+func (f *ClientFixture) TestSendLookupWithContextAndAuth_CredentialSignsRequest() {
+	f.sender.response = `{"meta": {"lines": 42}}`
+	f.input.Text = "42"
+	ctx := context.WithValue(context.Background(), "key", "value")
+
+	err := f.client.SendLookupWithContextAndAuth(ctx, f.input, sdk.NewSecretKeyCredential("myAuthID", "myAuthToken"))
+
+	f.So(err, should.BeNil)
+	f.So(f.sender.request, should.NotBeNil)
+	f.So(f.sender.request.Context(), should.Equal, ctx)
+	f.So(f.sender.request.URL.Query().Get("auth-id"), should.Equal, "myAuthID")
+	f.So(f.sender.request.URL.Query().Get("auth-token"), should.Equal, "myAuthToken")
+}
+
+func (f *ClientFixture) TestSendLookupWithContextAndAuth_NilCredentialDoesNotSign() {
+	f.sender.response = `{"meta": {"lines": 42}}`
+	f.input.Text = "42"
+	ctx := context.Background()
+
+	err := f.client.SendLookupWithContextAndAuth(ctx, f.input, nil)
+
+	f.So(err, should.BeNil)
+	f.So(f.sender.request, should.NotBeNil)
+	f.So(f.sender.request.URL.Query().Get("auth-id"), should.BeEmpty)
+	f.So(f.sender.request.URL.Query().Get("auth-token"), should.BeEmpty)
 }
 
 /*////////////////////////////////////////////////////////////////////////*/

--- a/us-reverse-geo-api/client.go
+++ b/us-reverse-geo-api/client.go
@@ -18,17 +18,17 @@ func NewClient(sender sdk.RequestSender) *Client {
 }
 
 func (c *Client) SendLookup(lookup *Lookup) error {
-	return c.SendLookupWithContextAndAuth(context.Background(), lookup, "", "")
+	return c.SendLookupWithContextAndAuth(context.Background(), lookup, nil)
 }
 
 func (c *Client) SendLookupWithContext(ctx context.Context, lookup *Lookup) error {
-	return c.SendLookupWithContextAndAuth(ctx, lookup, "", "")
+	return c.SendLookupWithContextAndAuth(ctx, lookup, nil)
 }
 
 // SendLookupWithContextAndAuth sends a lookup with the provided context and per-request credentials.
-// If authID and authToken are both non-empty, they will be used for this request instead of the client-level credentials.
+// If credential is non-nil, it will be used to sign this request instead of the client-level credentials.
 // This is useful for multi-tenant scenarios where different requests require different credentials.
-func (c *Client) SendLookupWithContextAndAuth(ctx context.Context, lookup *Lookup, authID, authToken string) error {
+func (c *Client) SendLookupWithContextAndAuth(ctx context.Context, lookup *Lookup, credential sdk.Credential) error {
 	if lookup == nil {
 		return nil
 	}
@@ -38,8 +38,8 @@ func (c *Client) SendLookupWithContextAndAuth(ctx context.Context, lookup *Looku
 
 	request := buildRequest(lookup)
 	request = request.WithContext(ctx)
-	if len(authID) > 0 && len(authToken) > 0 {
-		request.SetBasicAuth(authID, authToken)
+	if credential != nil {
+		credential.Sign(request)
 	}
 
 	response, err := c.sender.Send(request)

--- a/us-reverse-geo-api/client.go
+++ b/us-reverse-geo-api/client.go
@@ -39,7 +39,9 @@ func (c *Client) SendLookupWithContextAndAuth(ctx context.Context, lookup *Looku
 	request := buildRequest(lookup)
 	request = request.WithContext(ctx)
 	if credential != nil {
-		credential.Sign(request)
+		if err := credential.Sign(request); err != nil {
+			return err
+		}
 	}
 
 	response, err := c.sender.Send(request)

--- a/us-reverse-geo-api/client_test.go
+++ b/us-reverse-geo-api/client_test.go
@@ -190,7 +190,7 @@ func (f *ClientFixture) TestSendLookupWithContextAndAuth_SignErrorPropagated() {
 	f.input.Latitude = 40.123456789
 	f.input.Longitude = -111
 
-	err := f.client.SendLookupWithContextAndAuth(context.Background(), f.input, &FakeCredential{err: errors.New("sign failed")})
+	err := f.client.SendLookupWithContextAndAuth(context.Background(), f.input, &sdk.FakeCredential{Err: errors.New("sign failed")})
 
 	f.So(err, should.NotBeNil)
 	f.So(err.Error(), should.Equal, "sign failed")
@@ -198,14 +198,6 @@ func (f *ClientFixture) TestSendLookupWithContextAndAuth_SignErrorPropagated() {
 }
 
 /**************************************************************************/
-
-type FakeCredential struct {
-	err error
-}
-
-func (f *FakeCredential) Sign(*http.Request) error {
-	return f.err
-}
 
 type FakeSender struct {
 	callCount int

--- a/us-reverse-geo-api/client_test.go
+++ b/us-reverse-geo-api/client_test.go
@@ -185,7 +185,27 @@ var validResponseJSON = `{
   ]
 }`
 
+func (f *ClientFixture) TestSendLookupWithContextAndAuth_SignErrorPropagated() {
+	f.sender.response = validResponseJSON
+	f.input.Latitude = 40.123456789
+	f.input.Longitude = -111
+
+	err := f.client.SendLookupWithContextAndAuth(context.Background(), f.input, &FakeCredential{err: errors.New("sign failed")})
+
+	f.So(err, should.NotBeNil)
+	f.So(err.Error(), should.Equal, "sign failed")
+	f.So(f.sender.request, should.BeNil)
+}
+
 /**************************************************************************/
+
+type FakeCredential struct {
+	err error
+}
+
+func (f *FakeCredential) Sign(*http.Request) error {
+	return f.err
+}
 
 type FakeSender struct {
 	callCount int

--- a/us-reverse-geo-api/client_test.go
+++ b/us-reverse-geo-api/client_test.go
@@ -8,7 +8,8 @@ import (
 
 	"github.com/smarty/assertions/should"
 	"github.com/smarty/gunit"
-	"github.com/smartystreets/smartystreets-go-sdk"
+
+	sdk "github.com/smartystreets/smartystreets-go-sdk"
 )
 
 func TestClientFixture(t *testing.T) {
@@ -116,6 +117,35 @@ func (f *ClientFixture) TestDeserializationErrorPreventsDeserialization() {
 
 	f.So(err, should.NotBeNil)
 	f.So(f.input.Response.Results, should.BeEmpty)
+}
+
+func (f *ClientFixture) TestSendLookupWithContextAndAuth_CredentialSignsRequest() {
+	f.sender.response = validResponseJSON
+	f.input.Latitude = 40.123456789
+	f.input.Longitude = -111
+	ctx := context.WithValue(context.Background(), "key", "value")
+
+	err := f.client.SendLookupWithContextAndAuth(ctx, f.input, sdk.NewSecretKeyCredential("myAuthID", "myAuthToken"))
+
+	f.So(err, should.BeNil)
+	f.So(f.sender.request, should.NotBeNil)
+	f.So(f.sender.request.Context(), should.Equal, ctx)
+	f.So(f.sender.request.URL.Query().Get("auth-id"), should.Equal, "myAuthID")
+	f.So(f.sender.request.URL.Query().Get("auth-token"), should.Equal, "myAuthToken")
+}
+
+func (f *ClientFixture) TestSendLookupWithContextAndAuth_NilCredentialDoesNotSign() {
+	f.sender.response = validResponseJSON
+	f.input.Latitude = 40.123456789
+	f.input.Longitude = -111
+	ctx := context.Background()
+
+	err := f.client.SendLookupWithContextAndAuth(ctx, f.input, nil)
+
+	f.So(err, should.BeNil)
+	f.So(f.sender.request, should.NotBeNil)
+	f.So(f.sender.request.URL.Query().Get("auth-id"), should.BeEmpty)
+	f.So(f.sender.request.URL.Query().Get("auth-token"), should.BeEmpty)
 }
 
 var validResponseJSON = `{

--- a/us-reverse-geo-api/client_test.go
+++ b/us-reverse-geo-api/client_test.go
@@ -12,6 +12,8 @@ import (
 	sdk "github.com/smartystreets/smartystreets-go-sdk"
 )
 
+type testContextKey string
+
 func TestClientFixture(t *testing.T) {
 	gunit.Run(new(ClientFixture), t)
 }
@@ -36,7 +38,7 @@ func (f *ClientFixture) TestAddressLookupSerializedAndSentWithContext__ResponseS
 	f.input.Latitude = 40.123456789
 	f.input.Longitude = -111
 
-	ctx := context.WithValue(context.Background(), "key", "value")
+	ctx := context.WithValue(context.Background(), testContextKey("key"), "value")
 	err := f.client.SendLookupWithContext(ctx, f.input)
 
 	f.So(err, should.BeNil)
@@ -123,7 +125,7 @@ func (f *ClientFixture) TestSendLookupWithContextAndAuth_CredentialSignsRequest(
 	f.sender.response = validResponseJSON
 	f.input.Latitude = 40.123456789
 	f.input.Longitude = -111
-	ctx := context.WithValue(context.Background(), "key", "value")
+	ctx := context.WithValue(context.Background(), testContextKey("key"), "value")
 
 	err := f.client.SendLookupWithContextAndAuth(ctx, f.input, sdk.NewSecretKeyCredential("myAuthID", "myAuthToken"))
 

--- a/us-street-api/client.go
+++ b/us-street-api/client.go
@@ -19,24 +19,24 @@ func NewClient(sender sdk.RequestSender) *Client {
 
 // SendBatch sends the batch of inputs, populating the output for each input if the batch was successful.
 func (c *Client) SendBatch(batch *Batch) error {
-	return c.SendBatchWithContextAndAuth(context.Background(), batch, "", "")
+	return c.SendBatchWithContextAndAuth(context.Background(), batch, nil)
 }
 
 func (c *Client) SendBatchWithContext(ctx context.Context, batch *Batch) error {
-	return c.SendBatchWithContextAndAuth(ctx, batch, "", "")
+	return c.SendBatchWithContextAndAuth(ctx, batch, nil)
 }
 
 // SendBatchWithContextAndAuth sends a batch of lookups with the provided context and per-request credentials.
-// If authID and authToken are both non-empty, they will be used for this request instead of the client-level credentials.
+// If credential is non-nil, it will be used to sign this request instead of the client-level credentials.
 // This is useful for multi-tenant scenarios where different requests require different credentials.
-func (c *Client) SendBatchWithContextAndAuth(ctx context.Context, batch *Batch, authID, authToken string) error {
+func (c *Client) SendBatchWithContextAndAuth(ctx context.Context, batch *Batch, credential sdk.Credential) error {
 	if batch == nil || batch.Length() == 0 {
 		return nil
 	}
 	request := batch.buildRequest()
 	request = request.WithContext(ctx)
-	if len(authID) > 0 && len(authToken) > 0 {
-		request.SetBasicAuth(authID, authToken)
+	if credential != nil {
+		credential.Sign(request)
 	}
 	response, err := c.sender.Send(request)
 	if err != nil {

--- a/us-street-api/client.go
+++ b/us-street-api/client.go
@@ -36,7 +36,9 @@ func (c *Client) SendBatchWithContextAndAuth(ctx context.Context, batch *Batch, 
 	request := batch.buildRequest()
 	request = request.WithContext(ctx)
 	if credential != nil {
-		credential.Sign(request)
+		if err := credential.Sign(request); err != nil {
+			return err
+		}
 	}
 	response, err := c.sender.Send(request)
 	if err != nil {

--- a/us-street-api/client_test.go
+++ b/us-street-api/client_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/smarty/assertions/should"
 	"github.com/smarty/gunit"
+
 	sdk "github.com/smartystreets/smartystreets-go-sdk"
 )
 
@@ -369,6 +370,35 @@ func (f *ClientFixture) TestFullJSONResponseDeserialization() {
 			},
 		},
 	})
+}
+
+func (f *ClientFixture) TestSendBatchWithContextAndAuth_CredentialSignsRequest() {
+	f.sender.response = `[{"input_index": 0, "input_id": "42"}]`
+	input := &Lookup{InputID: "42"}
+	f.batch.Append(input)
+	ctx := context.WithValue(context.Background(), "key", "value")
+
+	err := f.client.SendBatchWithContextAndAuth(ctx, f.batch, sdk.NewSecretKeyCredential("myAuthID", "myAuthToken"))
+
+	f.So(err, should.BeNil)
+	f.So(f.sender.request, should.NotBeNil)
+	f.So(f.sender.request.Context(), should.Equal, ctx)
+	f.So(f.sender.request.URL.Query().Get("auth-id"), should.Equal, "myAuthID")
+	f.So(f.sender.request.URL.Query().Get("auth-token"), should.Equal, "myAuthToken")
+}
+
+func (f *ClientFixture) TestSendBatchWithContextAndAuth_NilCredentialDoesNotSign() {
+	f.sender.response = `[{"input_index": 0, "input_id": "42"}]`
+	input := &Lookup{InputID: "42"}
+	f.batch.Append(input)
+	ctx := context.Background()
+
+	err := f.client.SendBatchWithContextAndAuth(ctx, f.batch, nil)
+
+	f.So(err, should.BeNil)
+	f.So(f.sender.request, should.NotBeNil)
+	f.So(f.sender.request.URL.Query().Get("auth-id"), should.BeEmpty)
+	f.So(f.sender.request.URL.Query().Get("auth-token"), should.BeEmpty)
 }
 
 /*////////////////////////////////////////////////////////////////////////*/

--- a/us-street-api/client_test.go
+++ b/us-street-api/client_test.go
@@ -394,7 +394,7 @@ func (f *ClientFixture) TestSendBatchWithContextAndAuth_SignErrorPropagated() {
 	input := &Lookup{InputID: "42"}
 	f.batch.Append(input)
 
-	err := f.client.SendBatchWithContextAndAuth(context.Background(), f.batch, &FakeCredential{err: errors.New("sign failed")})
+	err := f.client.SendBatchWithContextAndAuth(context.Background(), f.batch, &sdk.FakeCredential{Err: errors.New("sign failed")})
 
 	f.So(err, should.NotBeNil)
 	f.So(err.Error(), should.Equal, "sign failed")
@@ -434,12 +434,4 @@ func (f *FakeSender) Send(request *http.Request) ([]byte, error) {
 		f.requestBody, _ = io.ReadAll(request.Body)
 	}
 	return []byte(f.response), f.err
-}
-
-type FakeCredential struct {
-	err error
-}
-
-func (f *FakeCredential) Sign(*http.Request) error {
-	return f.err
 }

--- a/us-street-api/client_test.go
+++ b/us-street-api/client_test.go
@@ -14,6 +14,8 @@ import (
 	sdk "github.com/smartystreets/smartystreets-go-sdk"
 )
 
+type testContextKey string
+
 func TestClientFixture(t *testing.T) {
 	gunit.Run(new(ClientFixture), t)
 }
@@ -37,7 +39,7 @@ func (f *ClientFixture) TestSingleAddressBatchWithContext_SentInQueryStringAsGET
 	input := &Lookup{InputID: "42"}
 	f.batch.Append(input)
 
-	ctx := context.WithValue(context.Background(), "key", "value")
+	ctx := context.WithValue(context.Background(), testContextKey("key"), "value")
 	err := f.client.SendBatchWithContext(ctx, f.batch)
 
 	f.So(err, should.BeNil)
@@ -376,7 +378,7 @@ func (f *ClientFixture) TestSendBatchWithContextAndAuth_CredentialSignsRequest()
 	f.sender.response = `[{"input_index": 0, "input_id": "42"}]`
 	input := &Lookup{InputID: "42"}
 	f.batch.Append(input)
-	ctx := context.WithValue(context.Background(), "key", "value")
+	ctx := context.WithValue(context.Background(), testContextKey("key"), "value")
 
 	err := f.client.SendBatchWithContextAndAuth(ctx, f.batch, sdk.NewSecretKeyCredential("myAuthID", "myAuthToken"))
 
@@ -385,6 +387,18 @@ func (f *ClientFixture) TestSendBatchWithContextAndAuth_CredentialSignsRequest()
 	f.So(f.sender.request.Context(), should.Equal, ctx)
 	f.So(f.sender.request.URL.Query().Get("auth-id"), should.Equal, "myAuthID")
 	f.So(f.sender.request.URL.Query().Get("auth-token"), should.Equal, "myAuthToken")
+}
+
+func (f *ClientFixture) TestSendBatchWithContextAndAuth_SignErrorPropagated() {
+	f.sender.response = `[{"input_index": 0, "input_id": "42"}]`
+	input := &Lookup{InputID: "42"}
+	f.batch.Append(input)
+
+	err := f.client.SendBatchWithContextAndAuth(context.Background(), f.batch, &FakeCredential{err: errors.New("sign failed")})
+
+	f.So(err, should.NotBeNil)
+	f.So(err.Error(), should.Equal, "sign failed")
+	f.So(f.sender.request, should.BeNil)
 }
 
 func (f *ClientFixture) TestSendBatchWithContextAndAuth_NilCredentialDoesNotSign() {
@@ -420,4 +434,12 @@ func (f *FakeSender) Send(request *http.Request) ([]byte, error) {
 		f.requestBody, _ = io.ReadAll(request.Body)
 	}
 	return []byte(f.response), f.err
+}
+
+type FakeCredential struct {
+	err error
+}
+
+func (f *FakeCredential) Sign(*http.Request) error {
+	return f.err
 }

--- a/us-zipcode-api/client.go
+++ b/us-zipcode-api/client.go
@@ -36,7 +36,9 @@ func (c *Client) SendBatchWithContextAndAuth(ctx context.Context, batch *Batch, 
 	request := batch.buildRequest()
 	request = request.WithContext(ctx)
 	if credential != nil {
-		credential.Sign(request)
+		if err := credential.Sign(request); err != nil {
+			return err
+		}
 	}
 
 	response, err := c.sender.Send(request)

--- a/us-zipcode-api/client.go
+++ b/us-zipcode-api/client.go
@@ -19,24 +19,24 @@ func NewClient(sender sdk.RequestSender) *Client {
 
 // SendBatch sends the batch of inputs, populating the output for each input if the batch was successful.
 func (c *Client) SendBatch(batch *Batch) error {
-	return c.SendBatchWithContextAndAuth(context.Background(), batch, "", "")
+	return c.SendBatchWithContextAndAuth(context.Background(), batch, nil)
 }
 
 func (c *Client) SendBatchWithContext(ctx context.Context, batch *Batch) error {
-	return c.SendBatchWithContextAndAuth(ctx, batch, "", "")
+	return c.SendBatchWithContextAndAuth(ctx, batch, nil)
 }
 
 // SendBatchWithContextAndAuth sends a batch of lookups with the provided context and per-request credentials.
-// If authID and authToken are both non-empty, they will be used for this request instead of the client-level credentials.
+// If credential is non-nil, it will be used to sign this request instead of the client-level credentials.
 // This is useful for multi-tenant scenarios where different requests require different credentials.
-func (c *Client) SendBatchWithContextAndAuth(ctx context.Context, batch *Batch, authID, authToken string) error {
+func (c *Client) SendBatchWithContextAndAuth(ctx context.Context, batch *Batch, credential sdk.Credential) error {
 	if batch == nil || batch.Length() == 0 {
 		return nil
 	}
 	request := batch.buildRequest()
 	request = request.WithContext(ctx)
-	if len(authID) > 0 && len(authToken) > 0 {
-		request.SetBasicAuth(authID, authToken)
+	if credential != nil {
+		credential.Sign(request)
 	}
 
 	response, err := c.sender.Send(request)

--- a/us-zipcode-api/client_test.go
+++ b/us-zipcode-api/client_test.go
@@ -150,7 +150,27 @@ func (f *ClientFixture) TestSendBatchWithContextAndAuth_NilCredentialDoesNotSign
 	f.So(f.sender.request.URL.Query().Get("auth-token"), should.BeEmpty)
 }
 
+func (f *ClientFixture) TestSendBatchWithContextAndAuth_SignErrorPropagated() {
+	f.sender.response = `[{"input_index": 0, "input_id": "42"}]`
+	input := &Lookup{InputID: "42", ZIPCode: "10001"}
+	f.batch.Append(input)
+
+	err := f.client.SendBatchWithContextAndAuth(context.Background(), f.batch, &FakeCredential{err: errors.New("sign failed")})
+
+	f.So(err, should.NotBeNil)
+	f.So(err.Error(), should.Equal, "sign failed")
+	f.So(f.sender.request, should.BeNil)
+}
+
 /*////////////////////////////////////////////////////////////////////////*/
+
+type FakeCredential struct {
+	err error
+}
+
+func (f *FakeCredential) Sign(*http.Request) error {
+	return f.err
+}
 
 type FakeSender struct {
 	callCount int

--- a/us-zipcode-api/client_test.go
+++ b/us-zipcode-api/client_test.go
@@ -14,6 +14,8 @@ import (
 	sdk "github.com/smartystreets/smartystreets-go-sdk"
 )
 
+type testContextKey string
+
 func TestClientFixture(t *testing.T) {
 	gunit.Run(new(ClientFixture), t)
 }
@@ -38,7 +40,7 @@ func (f *ClientFixture) TestSingleLookupSerializedInQueryStringGET() {
 	input := &Lookup{InputID: "42", ZIPCode: "10001", City: "NYC", State: "NY"}
 	f.batch.Append(input)
 
-	ctx := context.WithValue(context.Background(), "key", "value")
+	ctx := context.WithValue(context.Background(), testContextKey("key"), "value")
 	err := f.client.SendBatchWithContext(ctx, f.batch)
 
 	f.So(err, should.BeNil)
@@ -123,7 +125,7 @@ func (f *ClientFixture) TestSendBatchWithContextAndAuth_CredentialSignsRequest()
 	f.sender.response = `[{"input_index": 0, "input_id": "42"}]`
 	input := &Lookup{InputID: "42", ZIPCode: "10001"}
 	f.batch.Append(input)
-	ctx := context.WithValue(context.Background(), "key", "value")
+	ctx := context.WithValue(context.Background(), testContextKey("key"), "value")
 
 	err := f.client.SendBatchWithContextAndAuth(ctx, f.batch, sdk.NewSecretKeyCredential("myAuthID", "myAuthToken"))
 

--- a/us-zipcode-api/client_test.go
+++ b/us-zipcode-api/client_test.go
@@ -155,7 +155,7 @@ func (f *ClientFixture) TestSendBatchWithContextAndAuth_SignErrorPropagated() {
 	input := &Lookup{InputID: "42", ZIPCode: "10001"}
 	f.batch.Append(input)
 
-	err := f.client.SendBatchWithContextAndAuth(context.Background(), f.batch, &FakeCredential{err: errors.New("sign failed")})
+	err := f.client.SendBatchWithContextAndAuth(context.Background(), f.batch, &sdk.FakeCredential{Err: errors.New("sign failed")})
 
 	f.So(err, should.NotBeNil)
 	f.So(err.Error(), should.Equal, "sign failed")
@@ -163,14 +163,6 @@ func (f *ClientFixture) TestSendBatchWithContextAndAuth_SignErrorPropagated() {
 }
 
 /*////////////////////////////////////////////////////////////////////////*/
-
-type FakeCredential struct {
-	err error
-}
-
-func (f *FakeCredential) Sign(*http.Request) error {
-	return f.err
-}
 
 type FakeSender struct {
 	callCount int

--- a/us-zipcode-api/client_test.go
+++ b/us-zipcode-api/client_test.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/smarty/assertions/should"
 	"github.com/smarty/gunit"
+
+	sdk "github.com/smartystreets/smartystreets-go-sdk"
 )
 
 func TestClientFixture(t *testing.T) {
@@ -115,6 +117,35 @@ func (f *ClientFixture) TestDeserializationErrorPreventsDeserialization() {
 
 	f.So(err, should.NotBeNil)
 	f.So(input.Result, should.BeNil)
+}
+
+func (f *ClientFixture) TestSendBatchWithContextAndAuth_CredentialSignsRequest() {
+	f.sender.response = `[{"input_index": 0, "input_id": "42"}]`
+	input := &Lookup{InputID: "42", ZIPCode: "10001"}
+	f.batch.Append(input)
+	ctx := context.WithValue(context.Background(), "key", "value")
+
+	err := f.client.SendBatchWithContextAndAuth(ctx, f.batch, sdk.NewSecretKeyCredential("myAuthID", "myAuthToken"))
+
+	f.So(err, should.BeNil)
+	f.So(f.sender.request, should.NotBeNil)
+	f.So(f.sender.request.Context(), should.Equal, ctx)
+	f.So(f.sender.request.URL.Query().Get("auth-id"), should.Equal, "myAuthID")
+	f.So(f.sender.request.URL.Query().Get("auth-token"), should.Equal, "myAuthToken")
+}
+
+func (f *ClientFixture) TestSendBatchWithContextAndAuth_NilCredentialDoesNotSign() {
+	f.sender.response = `[{"input_index": 0, "input_id": "42"}]`
+	input := &Lookup{InputID: "42", ZIPCode: "10001"}
+	f.batch.Append(input)
+	ctx := context.Background()
+
+	err := f.client.SendBatchWithContextAndAuth(ctx, f.batch, nil)
+
+	f.So(err, should.BeNil)
+	f.So(f.sender.request, should.NotBeNil)
+	f.So(f.sender.request.URL.Query().Get("auth-id"), should.BeEmpty)
+	f.So(f.sender.request.URL.Query().Get("auth-token"), should.BeEmpty)
 }
 
 /*////////////////////////////////////////////////////////////////////////*/

--- a/website_key_credential.go
+++ b/website_key_credential.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 )
 
-func NewWebsiteKeyCredential(key, hostNameOrIP string) *websiteKeyCredential {
+func NewWebsiteKeyCredential(key, hostNameOrIP string) Credential {
 	if !strings.HasPrefix(hostNameOrIP, httpsScheme) && !strings.HasPrefix(hostNameOrIP, httpScheme) {
 		hostNameOrIP = httpScheme + hostNameOrIP
 	}


### PR DESCRIPTION
This redoes the XXXWithContextAndAuth endpoints to accept any of our Authentication types. It makes it possible for me to use the BasicAuth directly in the MCP server. It'll also be in preparation for OAuth eventually. 

I believe I was the only one using the original XXXWithContextAndAuth methods, so I went ahead and did a full breaking change without the deprecation.