### PR TITLE
Added getBuinessID to universal lookup.

### DIFF
--- a/us-enrichment-api/client.go
+++ b/us-enrichment-api/client.go
@@ -221,8 +221,10 @@ func buildRequest(lookup enrichmentLookup) *http.Request {
 }
 
 func buildLookupURL(lookup enrichmentLookup) string {
-	if bl, ok := lookup.(businessIDProvider); ok && len(bl.getBusinessID()) > 0 {
-		return "/lookup/" + lookup.getDataSet() + "/" + bl.getBusinessID()
+	if lookup.getDataSet() == businessDataSet {
+		if bl, ok := lookup.(businessIDProvider); ok && len(bl.getBusinessID()) > 0 {
+			return "/lookup/" + lookup.getDataSet() + "/" + bl.getBusinessID()
+		}
 	}
 
 	var newLookupURL string

--- a/us-enrichment-api/client_test.go
+++ b/us-enrichment-api/client_test.go
@@ -438,6 +438,30 @@ func (f *ClientFixture) TestSendUniversalLookupWithoutDataSubset() {
 	f.So(response, should.NotBeEmpty)
 }
 
+func (f *ClientFixture) TestSendUniversalLookupWithBusinessID() {
+	f.sender.response = validBusinessDetailResponse
+	lookup := &Lookup{BusinessID: "GEYTCMZSGU2TCMBZHE3DIOI"}
+
+	err, response := f.client.SendUniversalLookup(lookup, "business", "")
+
+	f.So(err, should.BeNil)
+	f.So(f.sender.request, should.NotBeNil)
+	f.So(f.sender.request.URL.Path, should.Equal, "/lookup/business/GEYTCMZSGU2TCMBZHE3DIOI")
+	f.So(response, should.NotBeEmpty)
+}
+
+func (f *ClientFixture) TestSendUniversalLookupBusinessIDIgnoredForNonBusinessDataset() {
+	f.sender.response = validPrincipalResponse
+	lookup := &Lookup{SmartyKey: "123", BusinessID: "GEYTCMZSGU2TCMBZHE3DIOI"}
+
+	err, response := f.client.SendUniversalLookup(lookup, "property", "principal")
+
+	f.So(err, should.BeNil)
+	f.So(f.sender.request, should.NotBeNil)
+	f.So(f.sender.request.URL.Path, should.Equal, "/lookup/123/property/principal")
+	f.So(response, should.NotBeEmpty)
+}
+
 // Tests for address search (freeform lookup without SmartyKey)
 
 func (f *ClientFixture) TestAddressSearchWithFreeform() {

--- a/us-enrichment-api/lookup.go
+++ b/us-enrichment-api/lookup.go
@@ -38,9 +38,8 @@ type universalLookup struct {
 	Response   []byte
 }
 
-func (g *universalLookup) getSmartyKey() string {
-	return g.Lookup.SmartyKey
-}
+func (g *universalLookup) getSmartyKey() string     { return g.Lookup.SmartyKey }
+func (g *universalLookup) getBusinessID() string    { return g.Lookup.BusinessID }
 func (g *universalLookup) getDataSet() string       { return g.DataSet }
 func (g *universalLookup) getDataSubset() string    { return g.DataSubset }
 func (g *universalLookup) getLookup() *Lookup       { return g.Lookup }


### PR DESCRIPTION
Universal Lookup was unable to submit a business data set because it didn't implement the businessIDProvider interface. Also added a check that only the businessDataSet is used when a businessID is also used.