### PR TITLE
Sync International Street Candidate with API output.

### DIFF
--- a/examples/international-street-api/main.go
+++ b/examples/international-street-api/main.go
@@ -52,10 +52,6 @@ func main() {
 		display(candidate.Address6)
 		display(candidate.Address7)
 		display(candidate.Address8)
-		display(candidate.Address9)
-		display(candidate.Address10)
-		display(candidate.Address11)
-		display(candidate.Address12)
 		fmt.Println()
 	}
 

--- a/international-street-api/candidate.go
+++ b/international-street-api/candidate.go
@@ -21,20 +21,15 @@ type (
 		Address6     string `json:"address6,omitempty"`
 		Address7     string `json:"address7,omitempty"`
 		Address8     string `json:"address8,omitempty"`
-		Address9     string `json:"address9,omitempty"`
-		Address10    string `json:"address10,omitempty"`
-		Address11    string `json:"address11,omitempty"`
-		Address12    string `json:"address12,omitempty"`
 	}
 
 	// Components contains all output fields defined here:
 	// https://smartystreets.com/docs/international-street-api#components
 	Components struct {
+		Attention                          string `json:"attention,omitempty"`
 		SuperAdministrativeArea            string `json:"super_administrative_area,omitempty"`
 		AdministrativeArea                 string `json:"administrative_area,omitempty"`
 		AdministrativeAreaISO2             string `json:"administrative_area_iso2,omitempty"`
-		AdministrativeAreaShort            string `json:"administrative_area_short,omitempty"`
-		AdministrativeAreaLong             string `json:"administrative_area_long,omitempty"`
 		SubAdministrativeArea              string `json:"sub_administrative_area,omitempty"`
 		Building                           string `json:"building,omitempty"`
 		DependentLocality                  string `json:"dependent_locality,omitempty"`
@@ -50,6 +45,11 @@ type (
 		PremiseNumber                      string `json:"premise_number,omitempty"`
 		PremiseType                        string `json:"premise_type,omitempty"`
 		PremisePrefixNumber                string `json:"premise_prefix_number,omitempty"`
+		ShortAddressCode                   string `json:"short_address_code,omitempty"`
+		SubBuildingLeadingType             string `json:"sub_building_leading_type,omitempty"`
+		SubBuildingBlock                   string `json:"sub_building_block,omitempty"`
+		SubBuildingDoor                    string `json:"sub_building_door,omitempty"`
+		SubBuildingStaircase               string `json:"sub_building_staircase,omitempty"`
 		Thoroughfare                       string `json:"thoroughfare,omitempty"`
 		ThoroughfarePredirection           string `json:"thoroughfare_predirection,omitempty"`
 		ThoroughfarePostdirection          string `json:"thoroughfare_postdirection,omitempty"`
@@ -108,6 +108,7 @@ type (
 	// https://smartystreets.com/docs/international-street-api#changes
 	Changes struct {
 		RootLevel
+		Country    string     `json:"country,omitempty"`
 		Components Components `json:"components,omitempty"`
 	}
 )

--- a/international-street-api/candidate.go
+++ b/international-street-api/candidate.go
@@ -108,7 +108,6 @@ type (
 	// https://smartystreets.com/docs/international-street-api#changes
 	Changes struct {
 		RootLevel
-		Country    string     `json:"country,omitempty"`
 		Components Components `json:"components,omitempty"`
 	}
 )

--- a/international-street-api/client_test.go
+++ b/international-street-api/client_test.go
@@ -130,16 +130,11 @@ func (f *ClientFixture) TestFullJSONResponseDeserialization() {
 	"address6": "also empty",
 	"address7": "there",
 	"address8": "is",
-	"address9": "nothing",
-	"address10": "to",
-	"address11": "show",
-	"address12": "here",
 	"components": {
+	  "attention": "Attn: John",
 	  "super_administrative_area": "super_blah",
 	  "administrative_area": "SP",
 	  "administrative_area_iso2": "BR-SP",
-	  "administrative_area_short": "SP",
-	  "administrative_area_long": "São Paulo",
 	  "sub_administrative_area": "sub_blah",
 	  "building": "building",
 	  "dependent_locality": "Casa Verde",
@@ -155,6 +150,11 @@ func (f *ClientFixture) TestFullJSONResponseDeserialization() {
 	  "premise_number": "121",
 	  "premise_type": "premise_type",
 	  "premise_prefix_number": "prefix",
+	  "short_address_code": "short_code",
+	  "sub_building_leading_type": "sub_lead",
+	  "sub_building_block": "sub_block",
+	  "sub_building_door": "sub_door",
+	  "sub_building_staircase": "sub_stair",
 	  "thoroughfare": "Rua Antônio Lopes Marin",
 	  "thoroughfare_predirection": "Q",
 	  "thoroughfare_postdirection": "K",
@@ -203,16 +203,12 @@ func (f *ClientFixture) TestFullJSONResponseDeserialization() {
 		"address6": "6",
 		"address7": "7",
 		"address8": "8",
-		"address9": "9",
-		"address10": "10",
-		"address11": "11",
-		"address12": "12",
+		"country": "Brazil",
 		"components": {
-	 	  "super_administrative_area": "blank",
+	 	  "attention": "Attn: John",
+		  "super_administrative_area": "blank",
 		  "administrative_area": "Verified-NoChange",
 		  "administrative_area_iso2": "Added",
-		  "administrative_area_short": "blank",
-		  "administrative_area_long": "blank",
 		  "sub_administrative_area": "blank",
 		  "building": "blank",
 		  "dependent_locality": "Added",
@@ -228,6 +224,11 @@ func (f *ClientFixture) TestFullJSONResponseDeserialization() {
 		  "premise_number": "Verified-NoChange",
 		  "premise_type": "blank",
 		  "premise_prefix_number": "blank",
+		  "short_address_code": "blank",
+		  "sub_building_leading_type": "blank",
+		  "sub_building_block": "blank",
+		  "sub_building_door": "blank",
+		  "sub_building_staircase": "blank",
 		  "thoroughfare": "Verified-SmallChange",
 		  "thoroughfare_predirection": "blank",
 		  "thoroughfare_postdirection": "blank",
@@ -282,15 +283,10 @@ func (f *ClientFixture) TestFullJSONResponseDeserialization() {
 	f.So(candidate.Address6, should.Equal, "also empty")
 	f.So(candidate.Address7, should.Equal, "there")
 	f.So(candidate.Address8, should.Equal, "is")
-	f.So(candidate.Address9, should.Equal, "nothing")
-	f.So(candidate.Address10, should.Equal, "to")
-	f.So(candidate.Address11, should.Equal, "show")
-	f.So(candidate.Address12, should.Equal, "here")
+	f.So(component.Attention, should.Equal, "Attn: John")
 	f.So(component.SuperAdministrativeArea, should.Equal, "super_blah")
 	f.So(component.AdministrativeArea, should.Equal, "SP")
 	f.So(component.AdministrativeAreaISO2, should.Equal, "BR-SP")
-	f.So(component.AdministrativeAreaShort, should.Equal, "SP")
-	f.So(component.AdministrativeAreaLong, should.Equal, "São Paulo")
 	f.So(component.SubAdministrativeArea, should.Equal, "sub_blah")
 	f.So(component.Building, should.Equal, "building")
 	f.So(component.DependentLocality, should.Equal, "Casa Verde")
@@ -306,6 +302,11 @@ func (f *ClientFixture) TestFullJSONResponseDeserialization() {
 	f.So(component.PremiseNumber, should.Equal, "121")
 	f.So(component.PremiseType, should.Equal, "premise_type")
 	f.So(component.PremisePrefixNumber, should.Equal, "prefix")
+	f.So(component.ShortAddressCode, should.Equal, "short_code")
+	f.So(component.SubBuildingLeadingType, should.Equal, "sub_lead")
+	f.So(component.SubBuildingBlock, should.Equal, "sub_block")
+	f.So(component.SubBuildingDoor, should.Equal, "sub_door")
+	f.So(component.SubBuildingStaircase, should.Equal, "sub_stair")
 	f.So(component.Thoroughfare, should.Equal, "Rua Antônio Lopes Marin")
 	f.So(component.ThoroughfarePredirection, should.Equal, "Q")
 	f.So(component.ThoroughfarePostdirection, should.Equal, "K")
@@ -349,10 +350,8 @@ func (f *ClientFixture) TestFullJSONResponseDeserialization() {
 	f.So(changes.Address6, should.Equal, "6")
 	f.So(changes.Address7, should.Equal, "7")
 	f.So(changes.Address8, should.Equal, "8")
-	f.So(changes.Address9, should.Equal, "9")
-	f.So(changes.Address10, should.Equal, "10")
-	f.So(changes.Address11, should.Equal, "11")
-	f.So(changes.Address12, should.Equal, "12")
+	f.So(changes.Country, should.Equal, "Brazil")
+	f.So(ccomponents.Attention, should.Equal, "Attn: John")
 	f.So(ccomponents.SuperAdministrativeArea, should.Equal, "blank")
 	f.So(ccomponents.AdministrativeArea, should.Equal, "Verified-NoChange")
 	f.So(ccomponents.SubAdministrativeArea, should.Equal, "blank")
@@ -370,6 +369,11 @@ func (f *ClientFixture) TestFullJSONResponseDeserialization() {
 	f.So(ccomponents.PremiseNumber, should.Equal, "Verified-NoChange")
 	f.So(ccomponents.PremiseType, should.Equal, "blank")
 	f.So(ccomponents.PremisePrefixNumber, should.Equal, "blank")
+	f.So(ccomponents.ShortAddressCode, should.Equal, "blank")
+	f.So(ccomponents.SubBuildingLeadingType, should.Equal, "blank")
+	f.So(ccomponents.SubBuildingBlock, should.Equal, "blank")
+	f.So(ccomponents.SubBuildingDoor, should.Equal, "blank")
+	f.So(ccomponents.SubBuildingStaircase, should.Equal, "blank")
 	f.So(ccomponents.Thoroughfare, should.Equal, "Verified-SmallChange")
 	f.So(ccomponents.ThoroughfarePredirection, should.Equal, "blank")
 	f.So(ccomponents.ThoroughfarePostdirection, should.Equal, "blank")

--- a/international-street-api/client_test.go
+++ b/international-street-api/client_test.go
@@ -203,7 +203,6 @@ func (f *ClientFixture) TestFullJSONResponseDeserialization() {
 		"address6": "6",
 		"address7": "7",
 		"address8": "8",
-		"country": "Brazil",
 		"components": {
 	 	  "attention": "Attn: John",
 		  "super_administrative_area": "blank",
@@ -350,7 +349,6 @@ func (f *ClientFixture) TestFullJSONResponseDeserialization() {
 	f.So(changes.Address6, should.Equal, "6")
 	f.So(changes.Address7, should.Equal, "7")
 	f.So(changes.Address8, should.Equal, "8")
-	f.So(changes.Country, should.Equal, "Brazil")
 	f.So(ccomponents.Attention, should.Equal, "Attn: John")
 	f.So(ccomponents.SuperAdministrativeArea, should.Equal, "blank")
 	f.So(ccomponents.AdministrativeArea, should.Equal, "Verified-NoChange")


### PR DESCRIPTION
Sync international-street-api Candidate struct with service output

- Remove Address9-Address12 from RootLevel (service caps at Address8)
- Add Attention, ShortAddressCode, SubBuildingLeadingType, SubBuildingBlock,
  SubBuildingDoor, SubBuildingStaircase to Components
- Remove AdministrativeAreaShort and AdministrativeAreaLong from Components
  (not returned by service or documented)
- Add Country to Changes (present in service view struct)