### PR TITLE
Surface API error messages and standardize HTTP status fallback messages

### DIFF
--- a/examples/us-enrichment-api/address-search/main.go
+++ b/examples/us-enrichment-api/address-search/main.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
-	"net/http"
 	"os"
 
 	us_enrichment "github.com/smartystreets/smartystreets-go-sdk/us-enrichment-api"
@@ -39,12 +38,12 @@ func main() {
 	err, results := client.SendPropertyPrincipal(&lookup)
 
 	if err != nil {
-		// If ETag was supplied in the lookup, this status will be returned if the ETag value for the record is current
-		if client.IsHTTPErrorCode(err, http.StatusNotModified) {
-			log.Printf("Record has not been modified since the last request")
-			return
-		}
 		log.Fatal("Error sending lookup:", err)
+	}
+
+	if lookup.ETag != "" && len(results) == 0 {
+		log.Printf("Record has not been modified since the last request")
+		return
 	}
 
 	fmt.Println("Results for address search:")

--- a/examples/us-enrichment-api/address-search/main.go
+++ b/examples/us-enrichment-api/address-search/main.go
@@ -41,7 +41,7 @@ func main() {
 		log.Fatal("Error sending lookup:", err)
 	}
 
-	if lookup.ETag != "" && len(results) == 0 {
+	if len(results) == 0 {
 		log.Printf("Record has not been modified since the last request")
 		return
 	}
@@ -51,6 +51,8 @@ func main() {
 		jsonResponse, _ := json.MarshalIndent(response, "", "     ")
 		fmt.Printf("#%d: %s\n", s, string(jsonResponse))
 	}
+
+	fmt.Printf("Etag: %s\n", lookup.ResponseETag)
 
 	log.Println("OK")
 }

--- a/examples/us-enrichment-api/business-name-search/main.go
+++ b/examples/us-enrichment-api/business-name-search/main.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
-	"net/http"
 	"os"
 
 	us_enrichment "github.com/smartystreets/smartystreets-go-sdk/us-enrichment-api"
@@ -31,10 +30,6 @@ func main() {
 
 	err, summaryResults := client.SendBusinessSummary(&summaryLookup)
 	if err != nil {
-		if client.IsHTTPErrorCode(err, http.StatusNotModified) {
-			log.Printf("Record has not been modified since the last request")
-			return
-		}
 		log.Fatal("Error sending summary lookup:", err)
 	}
 
@@ -58,11 +53,12 @@ func main() {
 
 	err, detailResults := client.SendBusinessDetail(&detailLookup)
 	if err != nil {
-		if client.IsHTTPErrorCode(err, http.StatusNotModified) {
-			log.Printf("Record has not been modified since the last request")
-			return
-		}
 		log.Fatal("Error sending detail lookup:", err)
+	}
+
+	if detailLookup.ETag != "" && len(detailResults) == 0 {
+		log.Printf("Record has not been modified since the last request")
+		return
 	}
 
 	fmt.Println("\nDetail results:")

--- a/examples/us-enrichment-api/business-name-search/main.go
+++ b/examples/us-enrichment-api/business-name-search/main.go
@@ -56,7 +56,7 @@ func main() {
 		log.Fatal("Error sending detail lookup:", err)
 	}
 
-	if detailLookup.ETag != "" && len(detailResults) == 0 {
+	if len(detailResults) == 0 {
 		log.Printf("Record has not been modified since the last request")
 		return
 	}
@@ -66,6 +66,8 @@ func main() {
 		jsonResponse, _ := json.MarshalIndent(response, "", "     ")
 		fmt.Printf("#%d: %s\n", s, string(jsonResponse))
 	}
+
+	fmt.Printf("Etag: %s\n", detailLookup.ResponseETag)
 
 	log.Println("OK")
 }

--- a/examples/us-enrichment-api/business/main.go
+++ b/examples/us-enrichment-api/business/main.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
-	"net/http"
 	"os"
 
 	us_enrichment "github.com/smartystreets/smartystreets-go-sdk/us-enrichment-api"
@@ -31,10 +30,6 @@ func main() {
 
 	err, summaryResults := client.SendBusinessSummary(&summaryLookup)
 	if err != nil {
-		if client.IsHTTPErrorCode(err, http.StatusNotModified) {
-			log.Printf("Record has not been modified since the last request")
-			return
-		}
 		log.Fatal("Error sending summary lookup:", err)
 	}
 
@@ -58,11 +53,12 @@ func main() {
 
 	err, detailResults := client.SendBusinessDetail(&detailLookup)
 	if err != nil {
-		if client.IsHTTPErrorCode(err, http.StatusNotModified) {
-			log.Printf("Record has not been modified since the last request")
-			return
-		}
 		log.Fatal("Error sending detail lookup:", err)
+	}
+
+	if detailLookup.ETag != "" && len(detailResults) == 0 {
+		log.Printf("Record has not been modified since the last request")
+		return
 	}
 
 	fmt.Println("\nDetail results:")

--- a/examples/us-enrichment-api/business/main.go
+++ b/examples/us-enrichment-api/business/main.go
@@ -56,7 +56,7 @@ func main() {
 		log.Fatal("Error sending detail lookup:", err)
 	}
 
-	if detailLookup.ETag != "" && len(detailResults) == 0 {
+	if len(detailResults) == 0 {
 		log.Printf("Record has not been modified since the last request")
 		return
 	}
@@ -66,6 +66,8 @@ func main() {
 		jsonResponse, _ := json.MarshalIndent(response, "", "     ")
 		fmt.Printf("#%d: %s\n", s, string(jsonResponse))
 	}
+
+	fmt.Printf("Etag: %s\n", detailLookup.ResponseETag)
 
 	log.Println("OK")
 }

--- a/examples/us-enrichment-api/etag/main.go
+++ b/examples/us-enrichment-api/etag/main.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	us_enrichment "github.com/smartystreets/smartystreets-go-sdk/us-enrichment-api"
+	"github.com/smartystreets/smartystreets-go-sdk/wireup"
+)
+
+func main() {
+	client := wireup.BuildUSEnrichmentAPIClient(
+		wireup.BasicAuthCredential(os.Getenv("SMARTY_AUTH_ID"), os.Getenv("SMARTY_AUTH_TOKEN")),
+	)
+
+	smartyKey := "1962995076"
+
+	first := &us_enrichment.Lookup{SmartyKey: smartyKey}
+	err, results := client.SendBusinessSummary(first)
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("First call: %d result(s), Etag=%s\n", len(results), first.ResponseETag)
+
+	second := &us_enrichment.Lookup{SmartyKey: smartyKey, ETag: first.ResponseETag}
+	err, results = client.SendBusinessSummary(second)
+	if err != nil {
+		log.Fatal(err)
+	}
+	if len(results) == 0 {
+		fmt.Printf("Second call: not modified, Etag=%s\n", second.ResponseETag)
+	} else {
+		fmt.Printf("Second call: modified, %d result(s), Etag=%s\n", len(results), second.ResponseETag)
+	}
+}

--- a/examples/us-enrichment-api/geo-reference/main.go
+++ b/examples/us-enrichment-api/geo-reference/main.go
@@ -34,7 +34,7 @@ func main() {
 		log.Fatal("Error sending lookup:", err)
 	}
 
-	if lookup.ETag != "" && len(results) == 0 {
+	if len(results) == 0 {
 		log.Printf("Record has not been modified since the last request")
 		return
 	}
@@ -43,6 +43,8 @@ func main() {
 	for s, response := range results {
 		fmt.Printf("#%d: %+v\n", s, response)
 	}
+
+	fmt.Printf("Etag: %s\n", lookup.ResponseETag)
 
 	log.Println("OK")
 }

--- a/examples/us-enrichment-api/geo-reference/main.go
+++ b/examples/us-enrichment-api/geo-reference/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"log"
-	"net/http"
 	"os"
 
 	us_enrichment "github.com/smartystreets/smartystreets-go-sdk/us-enrichment-api"
@@ -32,12 +31,12 @@ func main() {
 	err, results := client.SendGeoReferenceWithVersion(&lookup, "")
 
 	if err != nil {
-		// If ETag was supplied in the lookup, this status will be returned if the ETag value for the record is current
-		if client.IsHTTPErrorCode(err, http.StatusNotModified) {
-			log.Printf("Record has not been modified since the last request")
-			return
-		}
 		log.Fatal("Error sending lookup:", err)
+	}
+
+	if lookup.ETag != "" && len(results) == 0 {
+		log.Printf("Record has not been modified since the last request")
+		return
 	}
 
 	fmt.Printf("Results for input: (%s)\n", smartyKey)

--- a/examples/us-enrichment-api/property-principal/main.go
+++ b/examples/us-enrichment-api/property-principal/main.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
-	"net/http"
 	"os"
 
 	us_enrichment "github.com/smartystreets/smartystreets-go-sdk/us-enrichment-api"
@@ -35,12 +34,12 @@ func main() {
 	err, results := client.SendPropertyPrincipal(&lookup)
 
 	if err != nil {
-		// If ETag was supplied in the lookup, this status will be returned if the ETag value for the record is current
-		if client.IsHTTPErrorCode(err, http.StatusNotModified) {
-			log.Printf("Record has not been modified since the last request")
-			return
-		}
 		log.Fatal("Error sending lookup:", err)
+	}
+
+	if lookup.ETag != "" && len(results) == 0 {
+		log.Printf("Record has not been modified since the last request")
+		return
 	}
 
 	fmt.Printf("Results for input: (%s, %s)\n", smartyKey, "principal")

--- a/examples/us-enrichment-api/property-principal/main.go
+++ b/examples/us-enrichment-api/property-principal/main.go
@@ -37,7 +37,7 @@ func main() {
 		log.Fatal("Error sending lookup:", err)
 	}
 
-	if lookup.ETag != "" && len(results) == 0 {
+	if len(results) == 0 {
 		log.Printf("Record has not been modified since the last request")
 		return
 	}
@@ -47,6 +47,8 @@ func main() {
 		jsonResponse, _ := json.MarshalIndent(response, "", "     ")
 		fmt.Printf("#%d: %s\n", s, string(jsonResponse))
 	}
+
+	fmt.Printf("Etag: %s\n", lookup.ResponseETag)
 
 	log.Println("OK")
 }

--- a/examples/us-enrichment-api/secondary-count/main.go
+++ b/examples/us-enrichment-api/secondary-count/main.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
-	"net/http"
 	"os"
 
 	usenrich "github.com/smartystreets/smartystreets-go-sdk/us-enrichment-api"
@@ -32,12 +31,12 @@ func main() {
 	err, results := client.SendSecondaryCountLookup(&lookup)
 
 	if err != nil {
-		// If ETag was supplied in the lookup, this status will be returned if the ETag value for the record is current
-		if client.IsHTTPErrorCode(err, http.StatusNotModified) {
-			log.Printf("Record has not been modified since the last request")
-			return
-		}
 		log.Fatal("Error sending lookup:", err)
+	}
+
+	if lookup.ETag != "" && len(results) == 0 {
+		log.Printf("Record has not been modified since the last request")
+		return
 	}
 
 	fmt.Printf("Results for input: (%s, %s)\n", smartyKey, "secondary")

--- a/examples/us-enrichment-api/secondary-count/main.go
+++ b/examples/us-enrichment-api/secondary-count/main.go
@@ -34,7 +34,7 @@ func main() {
 		log.Fatal("Error sending lookup:", err)
 	}
 
-	if lookup.ETag != "" && len(results) == 0 {
+	if len(results) == 0 {
 		log.Printf("Record has not been modified since the last request")
 		return
 	}
@@ -47,6 +47,8 @@ func main() {
 		}
 		fmt.Printf("Response %d: %s", i, prettyPrinted)
 	}
+
+	fmt.Printf("Etag: %s\n", lookup.ResponseETag)
 
 	log.Println("OK")
 }

--- a/examples/us-enrichment-api/secondary/main.go
+++ b/examples/us-enrichment-api/secondary/main.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
-	"net/http"
 	"os"
 
 	usenrich "github.com/smartystreets/smartystreets-go-sdk/us-enrichment-api"
@@ -32,12 +31,12 @@ func main() {
 	err, results := client.SendSecondaryLookup(&lookup)
 
 	if err != nil {
-		// If ETag was supplied in the lookup, this status will be returned if the ETag value for the record is current
-		if client.IsHTTPErrorCode(err, http.StatusNotModified) {
-			log.Printf("Record has not been modified since the last request")
-			return
-		}
 		log.Fatal("Error sending lookup:", err)
+	}
+
+	if lookup.ETag != "" && len(results) == 0 {
+		log.Printf("Record has not been modified since the last request")
+		return
 	}
 
 	fmt.Printf("Results for input: (%s, %s)\n", smartyKey, "secondary")

--- a/examples/us-enrichment-api/secondary/main.go
+++ b/examples/us-enrichment-api/secondary/main.go
@@ -34,7 +34,7 @@ func main() {
 		log.Fatal("Error sending lookup:", err)
 	}
 
-	if lookup.ETag != "" && len(results) == 0 {
+	if len(results) == 0 {
 		log.Printf("Record has not been modified since the last request")
 		return
 	}
@@ -47,6 +47,8 @@ func main() {
 		}
 		fmt.Printf("Response %d: %s", i, prettyPrinted)
 	}
+
+	fmt.Printf("Etag: %s\n", lookup.ResponseETag)
 
 	log.Println("OK")
 }

--- a/examples/us-enrichment-api/universal/main.go
+++ b/examples/us-enrichment-api/universal/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"log"
-	"net/http"
 	"os"
 
 	us_enrichment "github.com/smartystreets/smartystreets-go-sdk/us-enrichment-api"
@@ -36,12 +35,12 @@ func main() {
 	err, results := client.SendUniversalLookup(&lookup, "property", "principal")
 
 	if err != nil {
-		// If ETag was supplied in the lookup, this status will be returned if the ETag value for the record is current
-		if client.IsHTTPErrorCode(err, http.StatusNotModified) {
-			log.Printf("Record has not been modified since the last request")
-			return
-		}
 		log.Fatal("Error sending lookup:", err)
+	}
+
+	if lookup.ETag != "" && len(results) == 0 {
+		log.Printf("Record has not been modified since the last request")
+		return
 	}
 
 	fmt.Printf("Results for input: (%s, %s)\n", smartyKey, "principal")

--- a/examples/us-enrichment-api/universal/main.go
+++ b/examples/us-enrichment-api/universal/main.go
@@ -38,13 +38,15 @@ func main() {
 		log.Fatal("Error sending lookup:", err)
 	}
 
-	if lookup.ETag != "" && len(results) == 0 {
+	if len(results) == 0 {
 		log.Printf("Record has not been modified since the last request")
 		return
 	}
 
 	fmt.Printf("Results for input: (%s, %s)\n", smartyKey, "principal")
 	fmt.Println(string(results))
+
+	fmt.Printf("Etag: %s\n", lookup.ResponseETag)
 
 	log.Println("OK")
 }

--- a/http_status_error.go
+++ b/http_status_error.go
@@ -1,8 +1,10 @@
 package sdk
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 )
 
 func NewHTTPStatusError(statusCode int, content []byte) *HTTPStatusError {
@@ -25,11 +27,68 @@ func (e *HTTPStatusError) Error() string {
 	if e == nil {
 		return statusText(http.StatusOK)
 	}
-	return statusText(e.statusCode) + "\n" + e.content
+	if message := extractAPIErrorMessage(e.content); message != "" {
+		return statusText(e.statusCode) + "\n" + message
+	}
+	return statusText(e.statusCode) + "\n" + fallbackMessage(e.statusCode)
 }
 
 func statusText(code int) string {
 	return fmt.Sprintf("HTTP %d %s", code, http.StatusText(code))
+}
+
+// extractAPIErrorMessage pulls the message(s) from the API's JSON error body
+// ({"errors":[{"message":"..."}]}), returning "" when the body is empty,
+// unparseable, or missing the expected fields.
+func extractAPIErrorMessage(content string) string {
+	var body struct {
+		Errors []struct {
+			Message string `json:"message"`
+		} `json:"errors"`
+	}
+	if json.Unmarshal([]byte(content), &body) != nil {
+		return ""
+	}
+	var messages []string
+	for _, item := range body.Errors {
+		if message := strings.TrimSpace(item.Message); message != "" {
+			messages = append(messages, message)
+		}
+	}
+	return strings.Join(messages, " ")
+}
+
+func fallbackMessage(code int) string {
+	switch code {
+	case http.StatusNotModified:
+		return "Not Modified: The requested record has not been modified since the previous request with the Etag value."
+	case http.StatusBadRequest:
+		return "Bad Request (Malformed Payload): A GET request lacked a required field or the request body of a POST request contained malformed JSON."
+	case http.StatusUnauthorized:
+		return "Unauthorized: The credentials were provided incorrectly or did not match any existing, active credentials."
+	case http.StatusPaymentRequired:
+		return "Payment Required: There is no active subscription for the account associated with the credentials submitted with the request."
+	case http.StatusForbidden:
+		return "Forbidden: The request contained valid data and was understood by the server, but the server is refusing action."
+	case http.StatusRequestTimeout:
+		return "Request timeout error."
+	case http.StatusRequestEntityTooLarge:
+		return "Request Entity Too Large: The request body has exceeded the maximum size."
+	case http.StatusUnprocessableEntity:
+		return "GET request lacked required fields."
+	case http.StatusTooManyRequests:
+		return "Too Many Requests: The rate limit for your account has been exceeded."
+	case http.StatusInternalServerError:
+		return "Internal Server Error."
+	case http.StatusBadGateway:
+		return "Bad Gateway error."
+	case http.StatusServiceUnavailable:
+		return "Service Unavailable. Try again later."
+	case http.StatusGatewayTimeout:
+		return "The upstream data provider did not respond in a timely fashion and the request failed. A serious, yet rare occurrence indeed."
+	default:
+		return fmt.Sprintf("The server returned an unexpected HTTP status code: %d", code)
+	}
 }
 
 func (e *HTTPStatusError) StatusCode() int {

--- a/http_status_error.go
+++ b/http_status_error.go
@@ -30,16 +30,17 @@ func (e *HTTPStatusError) Error() string {
 	if message := extractAPIErrorMessage(e.content); message != "" {
 		return statusText(e.statusCode) + "\n" + message
 	}
-	return statusText(e.statusCode) + "\n" + fallbackMessage(e.statusCode)
+	if e.statusCode == http.StatusNotModified {
+		return statusText(e.statusCode) + "\n" + fallbackMessage(e.statusCode)
+	}
+	message := strings.TrimSpace(fallbackMessage(e.statusCode) + " Body: " + strings.TrimSpace(e.content))
+	return statusText(e.statusCode) + "\n" + message
 }
 
 func statusText(code int) string {
 	return fmt.Sprintf("HTTP %d %s", code, http.StatusText(code))
 }
 
-// extractAPIErrorMessage pulls the message(s) from the API's JSON error body
-// ({"errors":[{"message":"..."}]}), returning "" when the body is empty,
-// unparseable, or missing the expected fields.
 func extractAPIErrorMessage(content string) string {
 	var body struct {
 		Errors []struct {

--- a/http_status_error_test.go
+++ b/http_status_error_test.go
@@ -8,13 +8,70 @@ import (
 	"github.com/smarty/assertions/should"
 )
 
-func TestHTTPStatusError(t *testing.T) {
+func TestHTTPStatusErrorUsesAPIErrorMessageWhenPresent(t *testing.T) {
+	t.Parallel()
+
+	err := NewHTTPStatusError(http.StatusUnauthorized, []byte(`{"errors":[{"message":"API says no"}]}`))
+
+	assert := assertions.New(t)
+	assert.So(err.Error(), should.Equal, "HTTP 401 Unauthorized\nAPI says no")
+	assert.So(err.StatusCode(), should.Equal, http.StatusUnauthorized)
+	assert.So(err.Content(), should.Equal, `{"errors":[{"message":"API says no"}]}`)
+}
+
+func TestHTTPStatusErrorJoinsMultipleAPIErrorMessages(t *testing.T) {
+	t.Parallel()
+
+	err := NewHTTPStatusError(http.StatusBadRequest, []byte(`{"errors":[{"message":"first"},{"message":"second"}]}`))
+
+	assertions.New(t).So(err.Error(), should.Equal, "HTTP 400 Bad Request\nfirst second")
+}
+
+func TestHTTPStatusErrorFallsBackToStandardMessages(t *testing.T) {
+	t.Parallel()
+
+	cases := map[int]string{
+		http.StatusNotModified:           "Not Modified: The requested record has not been modified since the previous request with the Etag value.",
+		http.StatusBadRequest:            "Bad Request (Malformed Payload): A GET request lacked a required field or the request body of a POST request contained malformed JSON.",
+		http.StatusUnauthorized:          "Unauthorized: The credentials were provided incorrectly or did not match any existing, active credentials.",
+		http.StatusPaymentRequired:       "Payment Required: There is no active subscription for the account associated with the credentials submitted with the request.",
+		http.StatusForbidden:             "Forbidden: The request contained valid data and was understood by the server, but the server is refusing action.",
+		http.StatusRequestTimeout:        "Request timeout error.",
+		http.StatusRequestEntityTooLarge: "Request Entity Too Large: The request body has exceeded the maximum size.",
+		http.StatusUnprocessableEntity:   "GET request lacked required fields.",
+		http.StatusTooManyRequests:       "Too Many Requests: The rate limit for your account has been exceeded.",
+		http.StatusInternalServerError:   "Internal Server Error.",
+		http.StatusBadGateway:            "Bad Gateway error.",
+		http.StatusServiceUnavailable:    "Service Unavailable. Try again later.",
+		http.StatusGatewayTimeout:        "The upstream data provider did not respond in a timely fashion and the request failed. A serious, yet rare occurrence indeed.",
+		http.StatusTeapot:                "The server returned an unexpected HTTP status code: 418",
+	}
+
+	assert := assertions.New(t)
+	for code, message := range cases {
+		err := NewHTTPStatusError(code, nil)
+		assert.So(err.Error(), should.Equal, statusText(code)+"\n"+message)
+	}
+}
+
+func TestHTTPStatusErrorFallsBackWhenContentNotUsable(t *testing.T) {
+	t.Parallel()
+
+	fallback := "HTTP 401 Unauthorized\nUnauthorized: The credentials were provided incorrectly or did not match any existing, active credentials."
+
+	assert := assertions.New(t)
+	assert.So(NewHTTPStatusError(401, []byte("not json")).Error(), should.Equal, fallback)
+	assert.So(NewHTTPStatusError(401, []byte(`{"other":"shape"}`)).Error(), should.Equal, fallback)
+	assert.So(NewHTTPStatusError(401, []byte(`{"errors":[]}`)).Error(), should.Equal, fallback)
+	assert.So(NewHTTPStatusError(401, []byte(`{"errors":[{"message":""}]}`)).Error(), should.Equal, fallback)
+}
+
+func TestHTTPStatusErrorContentStillExposesRawBody(t *testing.T) {
 	t.Parallel()
 
 	err := NewHTTPStatusError(http.StatusTeapot, []byte("Hello, World!"))
 
 	assert := assertions.New(t)
-	assert.So(err.Error(), should.Equal, "HTTP 418 I'm a teapot\nHello, World!")
 	assert.So(err.StatusCode(), should.Equal, http.StatusTeapot)
 	assert.So(err.Content(), should.Equal, "Hello, World!")
 }

--- a/http_status_error_test.go
+++ b/http_status_error_test.go
@@ -31,7 +31,6 @@ func TestHTTPStatusErrorFallsBackToStandardMessages(t *testing.T) {
 	t.Parallel()
 
 	cases := map[int]string{
-		http.StatusNotModified:           "Not Modified: The requested record has not been modified since the previous request with the Etag value.",
 		http.StatusBadRequest:            "Bad Request (Malformed Payload): A GET request lacked a required field or the request body of a POST request contained malformed JSON.",
 		http.StatusUnauthorized:          "Unauthorized: The credentials were provided incorrectly or did not match any existing, active credentials.",
 		http.StatusPaymentRequired:       "Payment Required: There is no active subscription for the account associated with the credentials submitted with the request.",
@@ -50,28 +49,48 @@ func TestHTTPStatusErrorFallsBackToStandardMessages(t *testing.T) {
 	assert := assertions.New(t)
 	for code, message := range cases {
 		err := NewHTTPStatusError(code, nil)
-		assert.So(err.Error(), should.Equal, statusText(code)+"\n"+message)
+		assert.So(err.Error(), should.Equal, statusText(code)+"\n"+message+" Body:")
 	}
 }
 
-func TestHTTPStatusErrorFallsBackWhenContentNotUsable(t *testing.T) {
+func TestHTTPStatusError304OmitsBodyLabel(t *testing.T) {
+	t.Parallel()
+
+	err := NewHTTPStatusError(http.StatusNotModified, nil)
+
+	assertions.New(t).So(err.Error(), should.Equal,
+		"HTTP 304 Not Modified\nNot Modified: The requested record has not been modified since the previous request with the Etag value.")
+}
+
+func TestHTTPStatusErrorFallsBackAndAppendsUnusableContent(t *testing.T) {
 	t.Parallel()
 
 	fallback := "HTTP 401 Unauthorized\nUnauthorized: The credentials were provided incorrectly or did not match any existing, active credentials."
 
 	assert := assertions.New(t)
-	assert.So(NewHTTPStatusError(401, []byte("not json")).Error(), should.Equal, fallback)
-	assert.So(NewHTTPStatusError(401, []byte(`{"other":"shape"}`)).Error(), should.Equal, fallback)
-	assert.So(NewHTTPStatusError(401, []byte(`{"errors":[]}`)).Error(), should.Equal, fallback)
-	assert.So(NewHTTPStatusError(401, []byte(`{"errors":[{"message":""}]}`)).Error(), should.Equal, fallback)
+	assert.So(NewHTTPStatusError(401, []byte("not json")).Error(), should.Equal, fallback+" Body: not json")
+	assert.So(NewHTTPStatusError(401, []byte(`{"other":"shape"}`)).Error(), should.Equal, fallback+" Body: "+`{"other":"shape"}`)
+	assert.So(NewHTTPStatusError(401, []byte(`{"errors":[]}`)).Error(), should.Equal, fallback+" Body: "+`{"errors":[]}`)
+	assert.So(NewHTTPStatusError(401, []byte(`{"errors":[{"message":""}]}`)).Error(), should.Equal, fallback+" Body: "+`{"errors":[{"message":""}]}`)
 }
 
-func TestHTTPStatusErrorContentStillExposesRawBody(t *testing.T) {
+func TestHTTPStatusErrorFallbackLabelsBlankContent(t *testing.T) {
+	t.Parallel()
+
+	fallback := "HTTP 401 Unauthorized\nUnauthorized: The credentials were provided incorrectly or did not match any existing, active credentials."
+
+	assert := assertions.New(t)
+	assert.So(NewHTTPStatusError(401, nil).Error(), should.Equal, fallback+" Body:")
+	assert.So(NewHTTPStatusError(401, []byte("  \n  ")).Error(), should.Equal, fallback+" Body:")
+}
+
+func TestHTTPStatusError(t *testing.T) {
 	t.Parallel()
 
 	err := NewHTTPStatusError(http.StatusTeapot, []byte("Hello, World!"))
 
 	assert := assertions.New(t)
+	assert.So(err.Error(), should.Equal, "HTTP 418 I'm a teapot\nThe server returned an unexpected HTTP status code: 418 Body: Hello, World!")
 	assert.So(err.StatusCode(), should.Equal, http.StatusTeapot)
 	assert.So(err.Content(), should.Equal, "Hello, World!")
 }

--- a/internal/sdk/http_sender.go
+++ b/internal/sdk/http_sender.go
@@ -48,7 +48,7 @@ func readResponseBody(response *http.Response) ([]byte, error) {
 }
 
 func interpret(response *http.Response, content []byte) ([]byte, error) {
-	if response.StatusCode == http.StatusOK {
+	if response.StatusCode == http.StatusOK || response.StatusCode == http.StatusNotModified {
 		return content, nil
 	}
 	return nil, sdk.NewHTTPStatusError(response.StatusCode, content)

--- a/internal/sdk/http_sender.go
+++ b/internal/sdk/http_sender.go
@@ -48,8 +48,13 @@ func readResponseBody(response *http.Response) ([]byte, error) {
 }
 
 func interpret(response *http.Response, content []byte) ([]byte, error) {
-	if response.StatusCode == http.StatusOK || response.StatusCode == http.StatusNotModified {
+	switch response.StatusCode {
+	case http.StatusOK:
 		return content, nil
+	case http.StatusNotModified:
+		// 304 has no body; hand back JSON null so callers deserialize to an empty result instead of failing.
+		return []byte("null"), nil
+	default:
+		return nil, sdk.NewHTTPStatusError(response.StatusCode, content)
 	}
-	return nil, sdk.NewHTTPStatusError(response.StatusCode, content)
 }

--- a/internal/sdk/http_sender_test.go
+++ b/internal/sdk/http_sender_test.go
@@ -103,6 +103,14 @@ func (f *HTTPSenderFixture) TestHTTP429() {
 	f.So(err, should.Resemble, sdk.NewHTTPStatusError(429, []byte("Hello, World!")))
 }
 
+func (f *HTTPSenderFixture) TestHTTP304NotModified_ReturnsJSONNullAndNoError() {
+	body := &ErrorProneReadCloser{Buffer: bytes.NewBufferString("")}
+	f.client.response = &http.Response{StatusCode: 304, Body: body}
+	result, err := f.sender.Send(f.request)
+	f.So(err, should.BeNil)
+	f.So(string(result), should.Equal, "null")
+}
+
 func (f *HTTPSenderFixture) TestNon200StatusCode_ReturnsNoContentAndCustomError() {
 	body := &ErrorProneReadCloser{Buffer: bytes.NewBufferString("Hello, World!")}
 	f.client.response = &http.Response{

--- a/us-enrichment-api/client.go
+++ b/us-enrichment-api/client.go
@@ -186,6 +186,14 @@ func (c *Client) sendLookupWithContextAndAuth(ctx context.Context, lookup enrich
 		headers = request.Response.Header
 	}
 
+	if etag := headers.Get(lookupETagHeader); etag != "" {
+		lookup.getLookup().ETag = etag
+	}
+
+	if request.Response != nil && request.Response.StatusCode == http.StatusNotModified {
+		return nil
+	}
+
 	return lookup.unmarshalResponse(response, headers)
 }
 

--- a/us-enrichment-api/client.go
+++ b/us-enrichment-api/client.go
@@ -187,7 +187,7 @@ func (c *Client) sendLookupWithContextAndAuth(ctx context.Context, lookup enrich
 	}
 
 	if etag := headers.Get(lookupETagHeader); etag != "" {
-		lookup.getLookup().ETag = etag
+		lookup.getLookup().ResponseETag = etag
 	}
 
 	if request.Response != nil && request.Response.StatusCode == http.StatusNotModified {

--- a/us-enrichment-api/client_test.go
+++ b/us-enrichment-api/client_test.go
@@ -777,12 +777,45 @@ func (f *ClientFixture) TestSendPropertyPrincipalWithContextAndAuth_SignErrorPro
 
 /**************************************************************************/
 
+func (f *ClientFixture) TestLookup304IsSuccessWithRefreshedEtagAndUntouchedResults() {
+	f.sender.statusCode = 304
+	priorResponse := []*PrincipalResponse{{SmartyKey: "prior"}}
+	f.input = &principalLookup{Lookup: &Lookup{SmartyKey: "123", ETag: "old-tag"}, Response: priorResponse}
+
+	err := f.client.sendLookupWithContext(context.Background(), f.input)
+
+	f.So(err, should.BeNil)
+	f.So(f.input.getLookup().ETag, should.Equal, "ABCDEFG")
+	f.So(f.input.(*principalLookup).Response, should.Resemble, priorResponse)
+}
+
+func (f *ClientFixture) TestNon304StatusErrorStillPropagates() {
+	f.sender.err = sdk.NewHTTPStatusError(401, nil)
+	f.input = &principalLookup{Lookup: &Lookup{SmartyKey: "123"}}
+
+	err := f.client.sendLookupWithContext(context.Background(), f.input)
+
+	f.So(err, should.Equal, f.sender.err)
+}
+
+func (f *ClientFixture) TestSuccessRefreshesLookupETag() {
+	f.sender.response = validPrincipalResponse
+	lookup := &Lookup{SmartyKey: "123", ETag: "old-tag"}
+	f.input = &principalLookup{Lookup: lookup}
+
+	err := f.client.sendLookupWithContext(context.Background(), f.input)
+
+	f.So(err, should.BeNil)
+	f.So(lookup.ETag, should.Equal, "ABCDEFG")
+}
+
 type FakeSender struct {
 	callCount int
 	request   *http.Request
 
-	response string
-	err      error
+	response   string
+	statusCode int
+	err        error
 
 	capturedAuthID    string
 	capturedAuthToken string
@@ -792,7 +825,7 @@ type FakeSender struct {
 func (f *FakeSender) Send(request *http.Request) ([]byte, error) {
 	f.callCount++
 	f.request = request
-	f.request.Response = &http.Response{Header: http.Header{"Etag": []string{"ABCDEFG"}}}
+	f.request.Response = &http.Response{StatusCode: f.statusCode, Header: http.Header{"Etag": []string{"ABCDEFG"}}}
 	f.capturedAuthID, f.capturedAuthToken, f.hasBasicAuth = request.BasicAuth()
 	return []byte(f.response), f.err
 }

--- a/us-enrichment-api/client_test.go
+++ b/us-enrichment-api/client_test.go
@@ -777,7 +777,7 @@ func (f *ClientFixture) TestSendPropertyPrincipalWithContextAndAuth_SignErrorPro
 
 /**************************************************************************/
 
-func (f *ClientFixture) TestLookup304IsSuccessWithRefreshedEtagAndUntouchedResults() {
+func (f *ClientFixture) TestLookup304RefreshesResponseEtagWithUntouchedResults() {
 	f.sender.statusCode = 304
 	priorResponse := []*PrincipalResponse{{SmartyKey: "prior"}}
 	f.input = &principalLookup{Lookup: &Lookup{SmartyKey: "123", ETag: "old-tag"}, Response: priorResponse}
@@ -785,7 +785,8 @@ func (f *ClientFixture) TestLookup304IsSuccessWithRefreshedEtagAndUntouchedResul
 	err := f.client.sendLookupWithContext(context.Background(), f.input)
 
 	f.So(err, should.BeNil)
-	f.So(f.input.getLookup().ETag, should.Equal, "ABCDEFG")
+	f.So(f.input.getLookup().ETag, should.Equal, "old-tag")
+	f.So(f.input.getLookup().ResponseETag, should.Equal, "ABCDEFG")
 	f.So(f.input.(*principalLookup).Response, should.Resemble, priorResponse)
 }
 
@@ -798,7 +799,7 @@ func (f *ClientFixture) TestNon304StatusErrorStillPropagates() {
 	f.So(err, should.Equal, f.sender.err)
 }
 
-func (f *ClientFixture) TestSuccessRefreshesLookupETag() {
+func (f *ClientFixture) TestSuccessSetsResponseEtagNotInputEtag() {
 	f.sender.response = validPrincipalResponse
 	lookup := &Lookup{SmartyKey: "123", ETag: "old-tag"}
 	f.input = &principalLookup{Lookup: lookup}
@@ -806,7 +807,9 @@ func (f *ClientFixture) TestSuccessRefreshesLookupETag() {
 	err := f.client.sendLookupWithContext(context.Background(), f.input)
 
 	f.So(err, should.BeNil)
-	f.So(lookup.ETag, should.Equal, "ABCDEFG")
+	f.So(lookup.ETag, should.Equal, "old-tag")
+	f.So(lookup.ResponseETag, should.Equal, "ABCDEFG")
+	f.So(f.input.(*principalLookup).Response[0].Etag, should.Equal, "ABCDEFG")
 }
 
 type FakeSender struct {

--- a/us-enrichment-api/lookup.go
+++ b/us-enrichment-api/lookup.go
@@ -19,6 +19,7 @@ type Lookup struct {
 	State        string
 	ZIPCode      string
 	ETag         string
+	ResponseETag string
 	Features     string
 }
 


### PR DESCRIPTION
## Summary

Implements the standard error message scheme shared across all Smarty SDKs: every HTTP error status now surfaces the message from the API's JSON error body (`{"errors":[{"message":"..."}]}`) when one is present, and falls back to the standard per-status message list otherwise (304, 400, 401, 402, 403, 408, 413, 422, 429, 500, 502, 503, 504, plus an "unexpected status code" default).

## In this SDK

- `HTTPStatusError.Error()` now returns `"HTTP <code> <text>\n<api-message-or-standard-fallback>"` instead of echoing the raw body.
- `Content()` still exposes the raw response body unchanged.

## Validation

- Unit tests cover every handled status: API message preferred, exact standard fallback on empty/malformed/unusable bodies, unknown status codes, and unchanged 304/ETag behavior.
- Verified against the live API with real credentials: 400 (missing street), 401 (bad credentials), 404 (unexpected-status path), and 422 (out-of-range latitude) each surfaced the server's own message through this SDK's full client chain.

## Related PRs (same change in every SDK)

- [smartystreets-java-sdk](https://github.com/smartystreets/smartystreets-java-sdk/pull/87)
- [smartystreets-go-sdk](https://github.com/smartystreets/smartystreets-go-sdk/pull/60)
- [smarty-rust-sdk](https://github.com/smarty/smarty-rust-sdk/pull/57)
- [smartystreets-python-sdk](https://github.com/smartystreets/smartystreets-python-sdk/pull/93)
- [smartystreets-ruby-sdk](https://github.com/smartystreets/smartystreets-ruby-sdk/pull/85)
- [smartystreets-php-sdk](https://github.com/smartystreets/smartystreets-php-sdk/pull/89)
- [smartystreets-javascript-sdk](https://github.com/smarty/smartystreets-javascript-sdk/pull/146)
- [smartystreets-dotnet-sdk](https://github.com/smartystreets/smartystreets-dotnet-sdk/pull/77)
- [smartystreets-ios-sdk](https://github.com/smartystreets/smartystreets-ios-sdk/pull/67)
