### PR TITLE
No batch post requests for US street, zip, or extract that use embedded keys

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,3 +68,4 @@ Three authentication strategies defined at root level:
 - `SecretKeyCredential` - adds auth-id/auth-token as query parameters
 - `BasicAuthCredential` - HTTP Basic Authentication header
 - `WebsiteKeyCredential` - for client-side applications with referrer restrictions
+- Embedded/website keys are GET-only — not valid for batch (POST) requests or the US Extract API (POST-only): https://www.smarty.com/docs/cloud/authentication

--- a/examples/us-extract-api/main.go
+++ b/examples/us-extract-api/main.go
@@ -17,7 +17,8 @@ func main() {
 	log.SetFlags(log.Ltime | log.Llongfile)
 
 	client := wireup.BuildUSExtractAPIClient(
-		//wireup.WebsiteKeyCredential(os.Getenv("SMARTY_AUTH_WEB"), os.Getenv("SMARTY_AUTH_REFERER")),
+		// The US Extract API is POST-only and embedded keys are restricted to GET, so this
+		// API requires secret keys: https://www.smarty.com/docs/cloud/authentication
 		wireup.BasicAuthCredential(os.Getenv("SMARTY_AUTH_ID"), os.Getenv("SMARTY_AUTH_TOKEN")),
 		// wireup.DebugHTTPOutput(), // uncomment this line to see detailed HTTP request/response information.
 	)

--- a/examples/us-street-api/main.go
+++ b/examples/us-street-api/main.go
@@ -15,7 +15,8 @@ func main() {
 
 	// You don't have to store your keys in environment variables, but we recommend it.
 	client := wireup.BuildUSStreetAPIClient(
-		//wireup.WebsiteKeyCredential(os.Getenv("SMARTY_AUTH_WEB"), os.Getenv("SMARTY_AUTH_REFERER")),
+		// Batch requests are sent via HTTP POST. Embedded keys are restricted to GET, so
+		// batches require secret keys: https://www.smarty.com/docs/cloud/authentication
 		wireup.BasicAuthCredential(os.Getenv("SMARTY_AUTH_ID"), os.Getenv("SMARTY_AUTH_TOKEN")),
 		// wireup.ViaProxy("https://my-proxy.my-company.com"), // uncomment this line to point to the specified proxy.
 		// wireup.DebugHTTPOutput(), // uncomment this line to see detailed HTTP request/response information.

--- a/examples/us-zipcode-api/main.go
+++ b/examples/us-zipcode-api/main.go
@@ -14,7 +14,8 @@ func main() {
 	log.SetFlags(log.Ltime | log.Llongfile)
 
 	client := wireup.BuildUSZIPCodeAPIClient(
-		//wireup.WebsiteKeyCredential(os.Getenv("SMARTY_AUTH_WEB"), os.Getenv("SMARTY_AUTH_REFERER")),
+		// Batch requests are sent via HTTP POST. Embedded keys are restricted to GET, so
+		// batches require secret keys: https://www.smarty.com/docs/cloud/authentication
 		wireup.BasicAuthCredential(os.Getenv("SMARTY_AUTH_ID"), os.Getenv("SMARTY_AUTH_TOKEN")),
 		// wireup.DebugHTTPOutput(), // uncomment this line to see detailed HTTP request/response information.
 	)


### PR DESCRIPTION
Change documentation and examples where necessary to get rid of any instances where a batch operation for US Street, US Zip code, or US Extract uses an embedded key.